### PR TITLE
Update ListItemWithIcon component styling

### DIFF
--- a/components/list/ListItemWithIcon.tsx
+++ b/components/list/ListItemWithIcon.tsx
@@ -3,7 +3,7 @@ import ListItem from '@mui/material/ListItem'
 import ListItemIcon from '@mui/material/ListItemIcon'
 import ListItemText from '@mui/material/ListItemText'
 import Typography from '@mui/material/Typography'
-import { designColor } from 'theme/theme'
+import { useTheme } from '@mui/material'
 
 type ListItemWithIconProps = {
   listIcon: ReactNode
@@ -11,6 +11,9 @@ type ListItemWithIconProps = {
 }
 
 const ListItemWithIcon = ({ listIcon, listText }: ListItemWithIconProps) => {
+  const theme = useTheme()
+  const palette = theme.palette
+
   return (
     <ListItem
       sx={{
@@ -18,12 +21,15 @@ const ListItemWithIcon = ({ listIcon, listText }: ListItemWithIconProps) => {
           '0px 4px 8px 2px rgba(52, 61, 62, 0.04), 0px 2px 4px rgba(52, 61, 62, 0.04)',
       }}
     >
-      <ListItemIcon sx={{ color: designColor.green.light }}>
+      <ListItemIcon sx={{ color: palette.primary.light }}>
         {listIcon}
       </ListItemIcon>
       <ListItemText
         primary={
-          <Typography variant="labelMedium" color={designColor.black}>
+          <Typography
+            variant="labelMedium"
+            color={palette.secondary.contrastText}
+          >
             {listText}
           </Typography>
         }


### PR DESCRIPTION
## What

Previous [Create ListItemWithIcon Component PR](https://github.com/openseattle/open-seattle-website/pull/24) used internal designColor instead of useTheme. Fixing in this PR.

## Why Do

useTheme so that future changes to palette will be automatically applied

## How Do

Import `ListItemWithIcon` component and test on page.

```
import * as React from 'react'
import Box from '@mui/material/Box'
import List from '@mui/material/List'
import DataObjectIcon from '@mui/icons-material/DataObject'
import CampaignIcon from '@mui/icons-material/Campaign'
import NoteAltIcon from '@mui/icons-material/NoteAlt'
import ListItemWithIcon from 'components/list/ListItemWithIcon'

export default function BasicList() {
  return (
    <Box
      sx={{
        boxSizing: 'border-box',
        width: '100%',
        maxWidth: 360,
        flex: '1',
        minWidth: { xs: '100%', sm: 'min-content' },
        boxShadow:
          '0px 4px 8px 2px rgba(52, 61, 62, 0.04), 0px 2px 4px rgba(52, 61, 62, 0.04)',
        borderRadius: '8px',
      }}
    >
      <List sx={{ margin: '10px' }}>
        <ListItemWithIcon
          listIcon={<CampaignIcon />}
          listText="Executive, Marketing, Administrative Direction"
        />
        <br />
        <ListItemWithIcon listIcon={<NoteAltIcon />} listText="UX Researcher" />
        <br />
        <ListItemWithIcon
          listIcon={<DataObjectIcon />}
          listText="Backend Developer"
        />
      </List>
    </Box>
  )
}
```

## Show Me
<img width="405" alt="Screenshot 2023-06-28 at 11 43 33 PM" src="https://github.com/openseattle/open-seattle-website/assets/131744661/43f9c74f-bef6-4c27-9877-649a584fd6f8">

