### PR TITLE
Polish about page based on feedback

### DIFF
--- a/components/CommonHeader.tsx
+++ b/components/CommonHeader.tsx
@@ -13,7 +13,6 @@ import Toolbar from '@mui/material/Toolbar'
 import { useRouter } from 'next/router'
 import * as React from 'react'
 import { theme } from 'theme/theme'
-import useMediaQuery from '@mui/material/useMediaQuery'
 
 import OSLogo from '../assets/darkThemeLogo.svg'
 
@@ -28,8 +27,6 @@ const page_mapping = {
 const CommonHeader = () => {
   // React states and functions for handling the hamburger menu.
   const [anchorElNav, setAnchorElNav] = React.useState<null | HTMLElement>(null)
-
-  const isSmallScreen = useMediaQuery('(max-width:700px)')
 
   const handleOpenNavMenu = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorElNav(event.currentTarget)
@@ -109,11 +106,13 @@ const CommonHeader = () => {
           </Menu>
         </Box>
         {/* Menu items that are shown on desktop */}
-        <Container
+        <Container disableGutters
           sx={{
             flexGrow: 1,
             display: { xs: 'none', lg: 'flex' },
             justifyContent: 'space-between',
+            paddingLeft: '2rem',
+            paddingRight: '2rem'
           }}
         >
           {/* LOGO */}

--- a/components/CommonHeader.tsx
+++ b/components/CommonHeader.tsx
@@ -83,7 +83,7 @@ const CommonHeader = () => {
             open={Boolean(anchorElNav)}
             onClose={handleCloseNavMenu}
             sx={{
-              display: { xs: 'block', md: 'none' },
+              display: { xs: 'block', md: 'block', lg: 'none' },
             }}
           >
             {Object.keys(page_mapping).map((name) => (
@@ -109,7 +109,7 @@ const CommonHeader = () => {
         <Container disableGutters
           sx={{
             flexGrow: 1,
-            display: { xs: 'none', lg: 'flex' },
+            display: { xs: 'none', md: 'none', lg: 'flex' },
             justifyContent: 'space-between',
             paddingLeft: '2rem',
             paddingRight: '2rem'

--- a/components/cards/CardRowContainer.tsx
+++ b/components/cards/CardRowContainer.tsx
@@ -12,6 +12,7 @@ const CardRowContainer = ({ children }: Props) => {
         display: 'grid',
         gridTemplateColumns: {
           xs: '1fr',
+          md: '1fr',
           lg: 'repeat(3, minmax(0, 1fr))',
         },
         gap: '2rem',

--- a/components/list/ListItemWithIcon.tsx
+++ b/components/list/ListItemWithIcon.tsx
@@ -8,17 +8,24 @@ import { ReactNode } from 'react'
 type ListItemWithIconProps = {
   listIcon?: ReactNode
   listText?: string
+  sxProps?: object
 }
 
-const ListItemWithIcon = ({ listIcon, listText }: ListItemWithIconProps) => {
+const ListItemWithIcon = ({
+  listIcon,
+  listText,
+  sxProps,
+}: ListItemWithIconProps) => {
   const theme = useTheme()
   const palette = theme.palette
 
   return (
     <ListItem
       sx={{
+        overflowWrap: 'break-word',
         boxShadow:
           '0px 4px 8px 2px rgba(52, 61, 62, 0.04), 0px 2px 4px rgba(52, 61, 62, 0.04)',
+        ...sxProps,
       }}
     >
       {listIcon && (

--- a/pages/about_new.tsx
+++ b/pages/about_new.tsx
@@ -37,6 +37,7 @@ import CardRowContainer from 'components/cards/CardRowContainer'
 import SectionContainer from 'components/layout/SectionContainer'
 import { withBasicLayout } from 'components/layouts'
 import ListItemWithIcon from 'components/list/ListItemWithIcon'
+import { useEffect, useState } from 'react'
 import { designColor } from 'theme/theme'
 
 import AboutUsImage from '../assets/aboutUs.png'
@@ -65,7 +66,7 @@ const AboutPage = () => {
       <WhatWeDoSection theme={theme} />
       <OurValueSection theme={theme} />
       <OurVisionSection theme={theme} />
-      <OurTeamSection theme={theme} extraSmallScreen={extraSmallScreen} />
+      <OurTeamSection />
     </Container>
   )
 }
@@ -153,17 +154,29 @@ const OurValueSection = ({ theme }) => (
       <CardOne
         title="Excellence"
         description="Striving for professional excellence means taking an uncompromising approach to the service we endeavor to provide. We ensure the utmost quality in what we deliver."
-        icon={<MilitaryTechOutlined style={{ color: designColor.white,  fontSize: '40px' }} />}
+        icon={
+          <MilitaryTechOutlined
+            style={{ color: designColor.white, fontSize: '40px' }}
+          />
+        }
       />
       <CardOne
         title="Efficacy"
         description="What we do have impact. We apply the pareto principle (and other frameworks) to ensure that we  optimize our efforts from engagement to delivery."
-        icon={<AutoGraphOutlined style={{ color: designColor.white, fontSize: '40px' }} />}
+        icon={
+          <AutoGraphOutlined
+            style={{ color: designColor.white, fontSize: '40px' }}
+          />
+        }
       />
       <CardOne
         title="Efficiency"
         description="We work with a steady and speedy cadence whenever possible. We maintain a MLP (minimum loveable product) mindset without sacrificing the quality of our work."
-        icon={<AccessAlarmOutlined style={{ color: designColor.white,  fontSize: '40px' }} />}
+        icon={
+          <AccessAlarmOutlined
+            style={{ color: designColor.white, fontSize: '40px' }}
+          />
+        }
       />
     </CardRowContainer>
   </AboutUsSection>
@@ -180,63 +193,76 @@ const OurVisionSection = ({ theme }) => (
   </AboutUsSection>
 )
 
-const OurTeamSection = ({ theme, extraSmallScreen }) => (
-  <AboutUsSection backgroundColor={theme.palette.background.default}>
-    <Typography variant="headlineMedium">Our team</Typography>
-    <Typography variant="bodyLarge" align="center" display="block">
-      The Open Seattle cadre is made up of highly skilled and committed
-      volunteers, dedicated to serving the greater Seattle area.
-    </Typography>
-    <Typography variant="titleMedium" align="center" display="block">
-      We’ve worked in tech and management for companies like:
-    </Typography>
-    <Grid container spacing={2}>
-      {companiesList.map((item) => (
-        <Grid item xs={6} md={4} key={item.label}>
-          <ListItemWithIcon
-            listIcon={item.icon}
-            listText={!extraSmallScreen && item.label}
-          />
-        </Grid>
-      ))}
-    </Grid>
-    <Typography variant="titleMedium" align="center" display="block">
-      We collectively hold experience in:
-    </Typography>
-    <Grid container spacing={2}>
-      {experienceContent.map((item) => (
-        <Grid item xs={6} md={4} key={item.label}>
-          <ListItemWithIcon
-            listIcon={!extraSmallScreen && item.icon}
-            listText={item.label}
-          />
-        </Grid>
-      ))}
-    </Grid>
-    <Typography variant="titleMedium" align="center" display="block">
-      And we have degrees in:
-    </Typography>
-    <Grid container spacing={2}>
-      {degreeContent.map((item) => (
-        <Grid item xs={6} md={4} key={item.label}>
-          <ListItemWithIcon
-            listIcon={!extraSmallScreen && item.icon}
-            listText={item.label}
-          />
-        </Grid>
-      ))}
-    </Grid>
-    <Box textAlign="center">
-      <Button
-        variant="contained"
-        href={'/project_individual'}
-        sx={{ width: 'fit-content' }}
-      >
-        View our Cadre
-      </Button>
-    </Box>
-  </AboutUsSection>
-)
+const OurTeamSection = () => {
+  const theme = useTheme()
+  const extraSmallScreen = useMediaQuery(theme.breakpoints.only('xs'))
+  const smallScreen = useMediaQuery(theme.breakpoints.only('sm'))
+  const mediumScreen = useMediaQuery(theme.breakpoints.only('md'))
+  const [isMediumOrSmallerScreen, setMedOrSmall] = useState(false)
+  useEffect(() => {
+    setMedOrSmall(smallScreen || mediumScreen || extraSmallScreen)
+  }, [extraSmallScreen, smallScreen, mediumScreen])
+
+  return (
+    <AboutUsSection backgroundColor={theme.palette.background.default}>
+      <Typography variant="headlineMedium">Our team</Typography>
+      <Typography variant="bodyLarge" align="center" display="block">
+        The Open Seattle cadre is made up of highly skilled and committed
+        volunteers, dedicated to serving the greater Seattle area.
+      </Typography>
+      <Typography variant="titleMedium" align="center" display="block">
+        We’ve worked in tech and management for companies like:
+      </Typography>
+      <Grid container spacing={2}>
+        {companiesList.map((item) => (
+          <Grid item xs={6} md={4} key={item.label}>
+            <ListItemWithIcon
+              listIcon={item.icon}
+              listText={!extraSmallScreen && item.label}
+            />
+          </Grid>
+        ))}
+      </Grid>
+      <Typography variant="titleMedium" align="center" display="block">
+        We collectively hold experience in:
+      </Typography>
+      <Grid container spacing={2}>
+        {experienceContent.map((item) => (
+          <Grid item xs={6} md={6} lg={4} key={item.label}>
+            <ListItemWithIcon
+              sxProps={!isMediumOrSmallerScreen && { height: '56px' }}
+              listIcon={!extraSmallScreen && item.icon}
+              listText={item.label}
+            />
+          </Grid>
+        ))}
+      </Grid>
+      <Typography variant="titleMedium" align="center" display="block">
+        And we have degrees in:
+      </Typography>
+      <Grid container spacing={2}>
+        {degreeContent.map((item) => (
+          <Grid item xs={6} md={6} lg={4} key={item.label}>
+            <ListItemWithIcon
+              sxProps={!isMediumOrSmallerScreen && { height: '56px' }}
+              listIcon={!extraSmallScreen && item.icon}
+              listText={item.label}
+            />
+          </Grid>
+        ))}
+      </Grid>
+      <Box textAlign="center">
+        <Button
+          variant="contained"
+          href={'/project_individual'}
+          sx={{ width: 'fit-content' }}
+        >
+          View our Cadre
+        </Button>
+      </Box>
+    </AboutUsSection>
+  )
+}
 
 const companiesList = [
   {

--- a/pages/about_new.tsx
+++ b/pages/about_new.tsx
@@ -37,7 +37,6 @@ import CardRowContainer from 'components/cards/CardRowContainer'
 import SectionContainer from 'components/layout/SectionContainer'
 import { withBasicLayout } from 'components/layouts'
 import ListItemWithIcon from 'components/list/ListItemWithIcon'
-import { useEffect, useState } from 'react'
 import { designColor } from 'theme/theme'
 
 import AboutUsImage from '../assets/aboutUs.png'
@@ -199,12 +198,7 @@ const OurVisionSection = ({ theme }) => (
 const OurTeamSection = () => {
   const theme = useTheme()
   const extraSmallScreen = useMediaQuery(theme.breakpoints.only('xs'))
-  const smallScreen = useMediaQuery(theme.breakpoints.only('sm'))
-  const mediumScreen = useMediaQuery(theme.breakpoints.only('md'))
-  const [isMediumOrSmallerScreen, setMedOrSmall] = useState(false)
-  useEffect(() => {
-    setMedOrSmall(smallScreen || mediumScreen || extraSmallScreen)
-  }, [extraSmallScreen, smallScreen, mediumScreen])
+  const isMediumOrSmallerScreen = useMediaQuery(theme.breakpoints.down('md'))
 
   return (
     <AboutUsSection backgroundColor={theme.palette.background.default}>

--- a/pages/about_new.tsx
+++ b/pages/about_new.tsx
@@ -54,7 +54,6 @@ import VerizonLogo from '../assets/aboutUsIcons/verizon.svg'
 
 const AboutPage = () => {
   const theme = useTheme()
-  const extraSmallScreen = useMediaQuery(theme.breakpoints.only('xs'))
 
   return (
     <Container
@@ -62,7 +61,7 @@ const AboutPage = () => {
       disableGutters
       sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}
     >
-      <AboutUsHeroSection theme={theme} extraSmallScreen={extraSmallScreen} />
+      <AboutUsHeroSection />
       <WhatWeDoSection theme={theme} />
       <OurValueSection theme={theme} />
       <OurVisionSection theme={theme} />
@@ -87,55 +86,59 @@ const AboutUsSection = ({ backgroundColor, children }) => (
   </SectionContainer>
 )
 
-const AboutUsHeroSection = ({ theme, extraSmallScreen }) => (
-  <SectionContainer backgroundColor={theme.palette.primary.main}>
-    <Box
-      sx={{
-        display: 'flex',
-        flexDirection: { xs: 'column', lg: 'row' },
-        alignItems: 'center',
-        gap: { xs: 4, md: '40px' },
-      }}
-      maxWidth={'880px'}
-    >
+const AboutUsHeroSection = () => {
+  const theme = useTheme();
+  const extraSmallScreen = useMediaQuery(theme.breakpoints.only('xs'));
+  const largeScreen = useMediaQuery(theme.breakpoints.up('lg'));
+  return (
+    <SectionContainer backgroundColor={theme.palette.primary.main}>
       <Box
         sx={{
-          textAlign: 'left',
-          width: '100%',
-          maxWidth: '418px',
           display: 'flex',
-          flexDirection: 'column',
-          gap: '2rem',
+          flexDirection: { xs: 'column', lg: 'row' },
+          alignItems: 'center',
+          gap: { xs: 4, md: '40px' },
         }}
       >
-        <Typography
-          variant={extraSmallScreen ? 'displayMedium' : 'displayLarge'}
-          sx={{ color: theme.palette.primary.contrastText }}
-        >
-          About us
-        </Typography>
-        <Typography
-          variant="bodyLarge"
+        <Box
           sx={{
-            color: theme.palette.primary.contrastText,
+            textAlign: 'left',
+            width: '100%',
+            maxWidth: largeScreen ? '418px' : '950px',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '2rem',
           }}
         >
-          Open Seattle comprises a group of seasoned professionals with
-          experience in web development, software engineering, digital strategy,
-          visual and content design, and more. We leverage this vast experience
-          to transform the nonprofit sector—to make it more efficient,
-          effective, and accessible to all.
-        </Typography>
+          <Typography
+            variant={extraSmallScreen ? 'displayMedium' : 'displayLarge'}
+            sx={{ color: theme.palette.primary.contrastText }}
+          >
+            About us
+          </Typography>
+          <Typography
+            variant="bodyLarge"
+            sx={{
+              color: theme.palette.primary.contrastText,
+            }}
+          >
+            Open Seattle comprises a group of seasoned professionals with
+            experience in web development, software engineering, digital
+            strategy, visual and content design, and more. We leverage this vast
+            experience to transform the nonprofit sector—to make it more
+            efficient, effective, and accessible to all.
+          </Typography>
+        </Box>
+        <img
+          src={AboutUsImage.src}
+          alt="About Us page graphic"
+          width="418px"
+          style={{ objectFit: 'cover' }}
+        />
       </Box>
-      <img
-        src={AboutUsImage.src}
-        alt="About Us page graphic"
-        width="418px"
-        style={{ objectFit: 'cover' }}
-      />
-    </Box>
-  </SectionContainer>
-)
+    </SectionContainer>
+  )
+}
 
 const WhatWeDoSection = ({ theme }) => (
   <AboutUsSection backgroundColor={designColor.white}>

--- a/pages/about_new.tsx
+++ b/pages/about_new.tsx
@@ -153,17 +153,17 @@ const OurValueSection = ({ theme }) => (
       <CardOne
         title="Excellence"
         description="Striving for professional excellence means taking an uncompromising approach to the service we endeavor to provide. We ensure the utmost quality in what we deliver."
-        icon={<MilitaryTechOutlined style={{ color: designColor.white }} />}
+        icon={<MilitaryTechOutlined style={{ color: designColor.white,  fontSize: '40px' }} />}
       />
       <CardOne
         title="Efficacy"
         description="What we do have impact. We apply the pareto principle (and other frameworks) to ensure that we  optimize our efforts from engagement to delivery."
-        icon={<AutoGraphOutlined style={{ color: designColor.white }} />}
+        icon={<AutoGraphOutlined style={{ color: designColor.white, fontSize: '40px' }} />}
       />
       <CardOne
         title="Efficiency"
         description="We work with a steady and speedy cadence whenever possible. We maintain a MLP (minimum loveable product) mindset without sacrificing the quality of our work."
-        icon={<AccessAlarmOutlined style={{ color: designColor.white }} />}
+        icon={<AccessAlarmOutlined style={{ color: designColor.white,  fontSize: '40px' }} />}
       />
     </CardRowContainer>
   </AboutUsSection>

--- a/pages/about_new.tsx
+++ b/pages/about_new.tsx
@@ -86,9 +86,9 @@ const AboutUsSection = ({ backgroundColor, children }) => (
 )
 
 const AboutUsHeroSection = () => {
-  const theme = useTheme();
-  const extraSmallScreen = useMediaQuery(theme.breakpoints.only('xs'));
-  const largeScreen = useMediaQuery(theme.breakpoints.up('lg'));
+  const theme = useTheme()
+  const extraSmallScreen = useMediaQuery(theme.breakpoints.only('xs'))
+  const largeScreen = useMediaQuery(theme.breakpoints.up('lg'))
   return (
     <SectionContainer backgroundColor={theme.palette.primary.main}>
       <Box
@@ -164,7 +164,7 @@ const OurValueSection = ({ theme }) => (
       />
       <CardOne
         title="Efficacy"
-        description="What we do have impact. We apply the pareto principle (and other frameworks) to ensure that we  optimize our efforts from engagement to delivery."
+        description="What we do will have impact. We will apply the pareto principle (and other frameworks) to ensure that we are optimizing our efforts at every step in our process from engagement to delivery."
         icon={
           <AutoGraphOutlined
             style={{ color: designColor.white, fontSize: '40px' }}


### PR DESCRIPTION
## What

Respond to design feedback from Kylie in https://www.figma.com/file/Qa1UC7cGLmEXbWXuRmgjpO/OS-Website-Annotations?type=whiteboard&node-id=136-244&t=b0ZTHbieDxjcHqTm-0

One of the change is align the hero section to the common header. I made changes to the header so that should fix places like volunteer page and other places that use a similar setup for hero section as well.

## Why Do

Need to touch up before we can publish this page.

## How Do
- useMediaQuery different API such as 'up' and 'down' to get range of screensize. so convenient! 
- some feedback were partially addressed when @mistyb01 pushed the card container changes #44
- I added some small changes to listitem so that the text doesn't go out of the boxes. 

## Show Me

Please see vercel. 
https://open-seattle-website-git-santina-polishabout-dev-openseattle.vercel.app/about_new
