### PR TITLE
Fixed “How can you help” -> ‘How you can help” in a footer

### DIFF
--- a/components/CommonFooter.tsx
+++ b/components/CommonFooter.tsx
@@ -98,7 +98,7 @@ const CommonFooterLargeScreen = () => (
     <GridItem md={4}>
       <FooterItemTitle>Support us</FooterItemTitle>
       <FooterSubItem>
-        <a href="mailto:info@openseattle.org">How can you help</a>
+        <a href="mailto:info@openseattle.org">How you can help</a>
       </FooterSubItem>
     </GridItem>
 
@@ -174,7 +174,7 @@ const CommonFooterMidScreen = () => (
         <Box>
           <FooterItemTitle>Support us</FooterItemTitle>
           <FooterSubItem>
-            <a href="mailto:info@openseattle.org">How can you help</a>
+            <a href="mailto:info@openseattle.org">How you can help</a>
           </FooterSubItem>
         </Box>
 
@@ -245,7 +245,7 @@ const CommonFooterSmallScreen = () => (
       <FooterItemTitle>Support us</FooterItemTitle>
       <FooterSubItem>
         {/* TODO Update to support-us page, when the page is added */}
-        <a href="mailto:info@openseattle.org">How can you help</a>
+        <a href="mailto:info@openseattle.org">How you can help</a>
       </FooterSubItem>
     </GridItem>
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -110,7 +110,12 @@ const Home = () => {
                 flexDirection: { xs: 'column', lg: 'row' },
               }}
             >
-              <Button variant="contained" color="secondary" size="small">
+              <Button
+                variant="contained"
+                color="secondary"
+                size="small"
+                href={'/partners'}
+              >
                 Partner With Us
               </Button>
               <Button
@@ -121,6 +126,7 @@ const Home = () => {
                   backgroundColor: '#004138',
                   marginBottom: { xs: '32px', md: '0px' },
                 }}
+                href={'/volunteers'}
               >
                 Volunteer With Us
               </Button>
@@ -245,6 +251,7 @@ const Home = () => {
           </Typography>
           <Button
             variant="contained"
+            href={'/about'}
             sx={{
               backgroundColor: palette.primary.dark,
               marginBottom: { sm: 4, lg: 10 },
@@ -256,6 +263,7 @@ const Home = () => {
             <CardOne
               description="Reach out to Open Seattle! We work with Washington-based nonprofits to create customized digital solutions for free."
               buttonText="Partner With Us"
+              buttonLink="/partners"
               icon={
                 <HandshakeOutlinedIcon
                   fontSize="large"
@@ -266,6 +274,7 @@ const Home = () => {
             <CardOne
               description="Join Open Seattle to make a difference in the lives of others—we have a wide range of volunteer opportunities available."
               buttonText="Volunteer With Us"
+              buttonLink="/volunteers"
               icon={
                 <Groups2OutlinedIcon
                   fontSize="large"


### PR DESCRIPTION
## What

Fixed “How can you help” -> ‘How you can help” in a footer

## Why Do

> Fixed a typo.

## How Do

> Implementation choices, reviewer notes, caveats, etc.

## Show Me

![01](https://github.com/openseattle/open-seattle-website/assets/58673729/0b344d37-5da3-4fad-a679-e7219c52b60a)


