### PR TITLE
Cadre page: updated 'roles needed', minor design fix

### DIFF
--- a/components/cards/CardWithPhoto.tsx
+++ b/components/cards/CardWithPhoto.tsx
@@ -4,7 +4,7 @@ import CardMedia from '@mui/material/CardMedia'
 import { useTheme } from '@mui/material/styles'
 import Typography from '@mui/material/Typography'
 import useMediaQuery from '@mui/material/useMediaQuery'
-
+import { Box } from '@mui/material'
 type CardWithPhotoProps = {
   title: string
   description: string
@@ -42,6 +42,7 @@ const CardWithPhoto = ({
         sx={{
           display: 'flex',
           flexDirection: 'column',
+          justifyContent: 'center',
           gap: '0.5rem',
           paddingBottom: '1rem !important',
         }}

--- a/components/list/ListItemWithIcon.tsx
+++ b/components/list/ListItemWithIcon.tsx
@@ -42,6 +42,7 @@ const ListItemWithIcon = ({
               color={palette.secondary.contrastText}
               sx={{
                 textTransform: 'capitalize',
+                display: 'inline-block',
               }}
             >
               {listText}

--- a/components/list/ListItemWithIcon.tsx
+++ b/components/list/ListItemWithIcon.tsx
@@ -22,6 +22,7 @@ const ListItemWithIcon = ({
   return (
     <ListItem
       sx={{
+        height: '3.5rem',
         overflowWrap: 'break-word',
         boxShadow:
           '0px 4px 8px 2px rgba(52, 61, 62, 0.04), 0px 2px 4px rgba(52, 61, 62, 0.04)',
@@ -39,6 +40,9 @@ const ListItemWithIcon = ({
             <Typography
               variant="labelMedium"
               color={palette.secondary.contrastText}
+              sx={{
+                textTransform: 'capitalize',
+              }}
             >
               {listText}
             </Typography>

--- a/components/list/ListItemWithIcon.tsx
+++ b/components/list/ListItemWithIcon.tsx
@@ -1,4 +1,4 @@
-import { Box, useTheme } from '@mui/material'
+import { useTheme } from '@mui/material'
 import ListItem from '@mui/material/ListItem'
 import ListItemIcon from '@mui/material/ListItemIcon'
 import ListItemText from '@mui/material/ListItemText'

--- a/pages/project_cadre.tsx
+++ b/pages/project_cadre.tsx
@@ -408,7 +408,13 @@ const ProjectIndividualPage = () => {
           <Subheader variant="headlineMedium" sx={{ textAlign: 'center' }}>
             Interested in volunteering with Open Seattle?
           </Subheader>
-          <Button variant="contained">Apply to volunteer</Button>
+          <Button
+            variant="contained"
+            href="https://airtable.com/embed/appTn3HE53SyGqWTJ/shr1lbcr3qmkoIbNW"
+            target="_blank"
+          >
+            Apply to volunteer
+          </Button>
         </Section>
       </SectionContainer>
     </>

--- a/pages/project_cadre.tsx
+++ b/pages/project_cadre.tsx
@@ -272,8 +272,8 @@ const ProjectIndividualPage = () => {
               sx={{
                 display: 'grid',
                 gridAutoFlow: 'columns',
-                gridTemplateColumns: 'repeat(auto-fill, minmax(12.5rem, 1fr))',
-                alignItems: 'center',
+                gridTemplateColumns: 'repeat(auto-fill, minmax(12.25rem, 1fr))',
+                // alignItems: 'flex-start',
                 justifyContent: 'center',
                 gap: '2rem',
                 width: '100%',

--- a/pages/project_cadre.tsx
+++ b/pages/project_cadre.tsx
@@ -375,7 +375,11 @@ const ProjectIndividualPage = () => {
               }}
             >
               {rolesNeeded.map((item) => (
-                <ListItemWithIcon listIcon={item.icon} listText={item.role} />
+                <ListItemWithIcon
+                  key={item.role}
+                  listIcon={item.icon}
+                  listText={item.role}
+                />
               ))}
             </Box>
           </Section>

--- a/pages/project_cadre.tsx
+++ b/pages/project_cadre.tsx
@@ -2,7 +2,6 @@ import { getTeamMembers } from '../sanity/lib/client'
 import { urlForImage } from '../sanity/lib/image'
 import { useEffect, useState } from 'react'
 
-import DataObjectIcon from '@mui/icons-material/DataObject'
 import {
   Box,
   Button,
@@ -20,6 +19,75 @@ import StateBadge from 'components/cards/StateBadge'
 import { withBasicLayout } from 'components/layouts'
 import ListItemWithIcon from 'components/list/ListItemWithIcon'
 import CardWithPhoto from 'components/cards/CardWithPhoto'
+
+// icons for role cards
+import CampaignOutlinedIcon from '@mui/icons-material/CampaignOutlined'
+import ScreenSearchDesktopOutlinedIcon from '@mui/icons-material/ScreenSearchDesktopOutlined'
+import DrawOutlinedIcon from '@mui/icons-material/DrawOutlined'
+import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined'
+import GavelRoundedIcon from '@mui/icons-material/GavelRounded'
+import Diversity3OutlinedIcon from '@mui/icons-material/Diversity3Outlined'
+import ManageAccountsOutlinedIcon from '@mui/icons-material/ManageAccountsOutlined'
+import ShareOutlinedIcon from '@mui/icons-material/ShareOutlined'
+import EmojiPeopleOutlinedIcon from '@mui/icons-material/EmojiPeopleOutlined'
+import CodeOutlinedIcon from '@mui/icons-material/CodeOutlined'
+import ApartmentOutlinedIcon from '@mui/icons-material/ApartmentOutlined'
+import AutoStoriesOutlinedIcon from '@mui/icons-material/AutoStoriesOutlined'
+
+const rolesNeeded = [
+  {
+    role: 'community engagement liaison',
+    icon: <CampaignOutlinedIcon />,
+  },
+  {
+    role: 'data analyst',
+    icon: <ScreenSearchDesktopOutlinedIcon />,
+  },
+  {
+    role: 'designer',
+    icon: <DrawOutlinedIcon />,
+  },
+  {
+    role: 'grant writer',
+    icon: <DescriptionOutlinedIcon />,
+  },
+  {
+    role: 'legal help',
+    icon: <GavelRoundedIcon />,
+  },
+  {
+    role: 'product manager',
+    icon: <Diversity3OutlinedIcon />,
+  },
+  {
+    role: 'project manager',
+    icon: <ManageAccountsOutlinedIcon />,
+  },
+  {
+    role: 'user experience researcher',
+    icon: <ScreenSearchDesktopOutlinedIcon />,
+  },
+  {
+    role: 'social media designer',
+    icon: <ShareOutlinedIcon />,
+  },
+  {
+    role: 'social media specialist',
+    icon: <EmojiPeopleOutlinedIcon />,
+  },
+  {
+    role: 'software engineer',
+    icon: <CodeOutlinedIcon />,
+  },
+  {
+    role: 'solution architect',
+    icon: <ApartmentOutlinedIcon />,
+  },
+  {
+    role: 'storyteller',
+    icon: <AutoStoriesOutlinedIcon />,
+  },
+]
 
 const ProjectIndividualPage = () => {
   const [teamData, setTeamData] = useState([])
@@ -273,7 +341,6 @@ const ProjectIndividualPage = () => {
                 display: 'grid',
                 gridAutoFlow: 'columns',
                 gridTemplateColumns: 'repeat(auto-fill, minmax(12.25rem, 1fr))',
-                // alignItems: 'flex-start',
                 justifyContent: 'center',
                 gap: '2rem',
                 width: '100%',
@@ -299,23 +366,17 @@ const ProjectIndividualPage = () => {
             </Subheader>
             <Box
               sx={{
-                display: 'flex',
-                flexDirection: { xs: 'column', lg: 'row' },
+                display: 'grid',
+                gridAutoFlow: 'columns',
+                gridTemplateColumns: 'repeat(auto-fill, minmax(15rem, 1fr))',
+                justifyContent: 'center',
                 gap: '2rem',
+                width: '100%',
               }}
             >
-              <ListItemWithIcon
-                listIcon={<DataObjectIcon />}
-                listText="UX Designer"
-              />
-              <ListItemWithIcon
-                listIcon={<DataObjectIcon />}
-                listText="Marketing Director"
-              />
-              <ListItemWithIcon
-                listIcon={<DataObjectIcon />}
-                listText="Backend Engineer"
-              />
+              {rolesNeeded.map((item) => (
+                <ListItemWithIcon listIcon={item.icon} listText={item.role} />
+              ))}
             </Box>
           </Section>
 

--- a/pages/project_cadre.tsx
+++ b/pages/project_cadre.tsx
@@ -131,7 +131,6 @@ const ProjectIndividualPage = () => {
             backgroundColor: theme.palette.primary.main,
             width: '100%',
             height: '28.75rem',
-            color: theme.palette.primary.contrastText,
             position: 'absolute',
             zIndex: '0',
           }}
@@ -141,6 +140,7 @@ const ProjectIndividualPage = () => {
           sx={{
             position: 'relative',
             padding: '4rem 1rem 0rem 1rem',
+            color: theme.palette.primary.contrastText,
           }}
         >
           <Stack>


### PR DESCRIPTION
## What

> Summary of what you're changing.

- Updated 'roles needed' section with roles DAS actually needs!
- Team section looks better after making it four columns, like the figma.
- Fixed broken 'apply to volunteer' link

## Why Do

> The motivation behind your change.

Address design feedback, update with real content.

## How Do

> Implementation choices, reviewer notes, caveats, etc.

The 'roles needed' section is static for now, i.e. not integrated with Sanity.

Side note, for implementing this with Sanity- I'm thinking having a set of predefined role titles, so they can be selected from a dropdown in Sanity, would be nice to have. And in our code, we could associate each role with a material UI icon.

## Show Me

> Screenshot of your change, if applicable.

card grid now has four columns at the widest breakpoint:
![image](https://github.com/openseattle/open-seattle-website/assets/60805050/0fc44f60-6915-4572-9492-aada2778f234)

populated the 'roles needed' section:
![image](https://github.com/openseattle/open-seattle-website/assets/60805050/6ec1b195-9d32-4325-936f-9c488498227a)


