### PR TITLE
Add QA specialist To List of Roles

### DIFF
--- a/pages/project_individual.tsx
+++ b/pages/project_individual.tsx
@@ -1,44 +1,42 @@
 /*
 * @2023 Digital Aid Seattle
 */
-import { urlForImage } from '../sanity/lib/image'
 import { useEffect, useState } from 'react'
+import { urlForImage } from '../sanity/lib/image'
 
 import {
   Box,
   Button,
-  Stack,
-  styled,
-  Typography,
-  useTheme,
   CircularProgress,
+  Stack,
+  Typography,
+  styled,
+  useTheme,
 } from '@mui/material'
 import useMediaQuery from '@mui/material/useMediaQuery'
 import SectionContainer from 'components/layout/SectionContainer'
 import { dasProjectsService } from './api/ProjectsService'
 
-// imports for placeholders-- delete as needed
-import ProjectPlaceholder from 'assets/logo-light-icon.svg'
+import CardWithPhoto from 'components/cards/CardWithPhoto'
 import StateBadge from 'components/cards/StateBadge'
 import { withBasicLayout } from 'components/layouts'
 import ListItemWithIcon from 'components/list/ListItemWithIcon'
-import CardWithPhoto from 'components/cards/CardWithPhoto'
 
 // icons for role cards
-import CampaignOutlinedIcon from '@mui/icons-material/CampaignOutlined'
-import ScreenSearchDesktopOutlinedIcon from '@mui/icons-material/ScreenSearchDesktopOutlined'
-import DrawOutlinedIcon from '@mui/icons-material/DrawOutlined'
-import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined'
-import GavelRoundedIcon from '@mui/icons-material/GavelRounded'
-import Diversity3OutlinedIcon from '@mui/icons-material/Diversity3Outlined'
-import ManageAccountsOutlinedIcon from '@mui/icons-material/ManageAccountsOutlined'
-import ShareOutlinedIcon from '@mui/icons-material/ShareOutlined'
-import EmojiPeopleOutlinedIcon from '@mui/icons-material/EmojiPeopleOutlined'
-import CodeOutlinedIcon from '@mui/icons-material/CodeOutlined'
 import ApartmentOutlinedIcon from '@mui/icons-material/ApartmentOutlined'
 import AutoStoriesOutlinedIcon from '@mui/icons-material/AutoStoriesOutlined'
+import BugReportOutlinedIcon from '@mui/icons-material/BugReportOutlined'
+import CampaignOutlinedIcon from '@mui/icons-material/CampaignOutlined'
+import CodeOutlinedIcon from '@mui/icons-material/CodeOutlined'
+import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined'
+import Diversity3OutlinedIcon from '@mui/icons-material/Diversity3Outlined'
+import DrawOutlinedIcon from '@mui/icons-material/DrawOutlined'
+import EmojiPeopleOutlinedIcon from '@mui/icons-material/EmojiPeopleOutlined'
+import GavelRoundedIcon from '@mui/icons-material/GavelRounded'
+import ManageAccountsOutlinedIcon from '@mui/icons-material/ManageAccountsOutlined'
+import ScreenSearchDesktopOutlinedIcon from '@mui/icons-material/ScreenSearchDesktopOutlined'
+import ShareOutlinedIcon from '@mui/icons-material/ShareOutlined'
 import { DASProject } from 'types'
-import { Image } from 'sanity'
 
 const rolesMap = {
   communityEngagementLiason: { role: 'community engagement liaison', icon: <CampaignOutlinedIcon />, },
@@ -54,6 +52,7 @@ const rolesMap = {
   softwareEngineer: { role: 'software engineer', icon: <CodeOutlinedIcon />, },
   solutionArchitect: { role: 'solution architect', icon: <ApartmentOutlinedIcon />, },
   storyteller: { role: 'storyteller', icon: <AutoStoriesOutlinedIcon />, },
+  qaSpecialist: { role: 'QA specialist', icon: <BugReportOutlinedIcon />, }
 }
 
 const ProjectIndividualPage = () => {

--- a/pages/project_individual.tsx
+++ b/pages/project_individual.tsx
@@ -52,7 +52,7 @@ const rolesMap = {
   softwareEngineer: { role: 'software engineer', icon: <CodeOutlinedIcon />, },
   solutionArchitect: { role: 'solution architect', icon: <ApartmentOutlinedIcon />, },
   storyteller: { role: 'storyteller', icon: <AutoStoriesOutlinedIcon />, },
-  qaSpecialist: { role: 'QA specialist', icon: <BugReportOutlinedIcon />, }
+  // qaSpecialist: { role: 'QA specialist', icon: <BugReportOutlinedIcon />, }
 }
 
 const ProjectIndividualPage = () => {
@@ -319,13 +319,15 @@ const ProjectIndividualPage = () => {
                 width: '100%',
               }}
             >
-              {project.rolesNeeded.map(item => (
-                <ListItemWithIcon
-                  key={item}
-                  listIcon={rolesMap[item].icon}
-                  listText={rolesMap[item].role}
-                />
-              ))}
+              {project.rolesNeeded
+                .filter(item => rolesMap[item])
+                .map(item => (
+                  <ListItemWithIcon
+                    key={item}
+                    listIcon={rolesMap[item].icon}
+                    listText={rolesMap[item].role}
+                  />
+                ))}
             </Box>
           </Section>
         }

--- a/pages/project_individual.tsx
+++ b/pages/project_individual.tsx
@@ -52,7 +52,7 @@ const rolesMap = {
   softwareEngineer: { role: 'software engineer', icon: <CodeOutlinedIcon />, },
   solutionArchitect: { role: 'solution architect', icon: <ApartmentOutlinedIcon />, },
   storyteller: { role: 'storyteller', icon: <AutoStoriesOutlinedIcon />, },
-  // qaSpecialist: { role: 'QA specialist', icon: <BugReportOutlinedIcon />, }
+  qaSpecialist: { role: 'QA specialist', icon: <BugReportOutlinedIcon />, }
 }
 
 const ProjectIndividualPage = () => {

--- a/sanity/schemas/dasProject.ts
+++ b/sanity/schemas/dasProject.ts
@@ -51,7 +51,9 @@ export default {
             name: 'status',
             type: 'string',
             title: 'Status',
-            list: ['active', 'recruiting', 'complete']
+            options: {
+                list: ['active', 'recruiting', 'complete']
+            }
         },
         {
             name: 'projectLink',
@@ -110,7 +112,27 @@ export default {
             name: 'rolesNeeded',
             type: 'array',
             title: 'Roles Needed',
-            of: [{ type: 'string' }]
+            of: [{
+                type: 'string',
+                options: {
+                    list: [
+                        {title: 'Community Engagement Liason', value: 'communityEngagementLiason'},
+                        {title: 'Data Analyst', value: 'dataAnalyst'},
+                        {title: 'Designer', value: 'designer'},
+                        {title: 'Grant Writer', value: 'grantWriter'},
+                        {title: 'Legal Help', value: 'legalHelp'},
+                        {title: 'Product Manager', value: 'productManager'},
+                        {title: 'Project Manager', value: 'projectManager'},
+                        {title: 'UX Researcher', value: 'uxResearcher'},
+                        {title: 'Social Media Designer', value: 'socialMediaDesigner'},
+                        {title: 'Social Media Specialist', value: 'socialMediaSpecialist'},
+                        {title: 'Software Engineer', value: 'softwareEngineer'},
+                        {title: 'Solution Architect', value: 'solutionArchitect'},
+                        {title: 'Storyteller', value: 'storyteller'},
+                        {title: 'QA Specialist', value: 'qaSpecialist'}
+                    ]
+                }
+            }]
         },
         {
             name: 'currentTeam',


### PR DESCRIPTION
## What

> Add QA specialist To List of Roles with icons and title

## Why Do

> To match internal Airtable data

## How Do

> Need to update CMS to add "qaSpecialist" for appropriate project

## Show Me
<img width="334" alt="Screenshot 2023-09-26 at 7 29 26 PM" src="https://github.com/openseattle/open-seattle-website/assets/11780107/85bd358c-0b16-42d5-86c7-5a586660d66c">

