### PR TITLE
Responsive fixes for About page

### DIFF
--- a/components/list/ListItemWithIcon.tsx
+++ b/components/list/ListItemWithIcon.tsx
@@ -3,6 +3,7 @@ import ListItem from '@mui/material/ListItem'
 import ListItemIcon from '@mui/material/ListItemIcon'
 import ListItemText from '@mui/material/ListItemText'
 import Typography from '@mui/material/Typography'
+
 import { ReactNode } from 'react'
 
 type ListItemWithIconProps = {
@@ -26,6 +27,10 @@ const ListItemWithIcon = ({
         overflowWrap: 'break-word',
         boxShadow:
           '0px 4px 8px 2px rgba(52, 61, 62, 0.04), 0px 2px 4px rgba(52, 61, 62, 0.04)',
+        display: 'flex',
+        justifyContent: 'center',
+        width: '100%',
+        alignItems: 'center',
         ...sxProps,
       }}
     >

--- a/components/list/ListItemWithIcon.tsx
+++ b/components/list/ListItemWithIcon.tsx
@@ -23,7 +23,7 @@ const ListItemWithIcon = ({
   return (
     <ListItem
       sx={{
-        height: '3.5rem',
+        minHeight: '3.5rem',
         overflowWrap: 'break-word',
         boxShadow:
           '0px 4px 8px 2px rgba(52, 61, 62, 0.04), 0px 2px 4px rgba(52, 61, 62, 0.04)',

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -201,7 +201,7 @@ const OurTeamSection = () => {
           <Grid item xs={6} md={4} key={item.label}>
             <ListItemWithIcon
               listIcon={item.icon}
-              listText={!extraSmallScreen && item.label}
+              listText={!isMediumOrSmallerScreen && item.label}
             />
           </Grid>
         ))}

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -120,7 +120,8 @@ const WhatWeDoSection = ({ theme }) => (
   <AboutUsSection backgroundColor={designColor.white}>
     <Typography variant="headlineMedium">What we do</Typography>
     <Typography variant="bodyLarge">
-      Digital Aid Seattle partners with other nonprofits to amplify their impact and to uplift communities through the power of technology.
+      Digital Aid Seattle partners with other nonprofits to amplify their impact
+      and to uplift communities through the power of technology.
     </Typography>
     <Box textAlign="center">
       <Button
@@ -210,7 +211,7 @@ const OurTeamSection = () => {
       </Typography>
       <Grid container spacing={2}>
         {experienceContent.map((item) => (
-          <Grid item xs={6} md={6} lg={4} key={item.label}>
+          <Grid item xs={12} md={6} lg={4} key={item.label}>
             <ListItemWithIcon
               sxProps={!isMediumOrSmallerScreen && { height: '56px' }}
               listIcon={!extraSmallScreen && item.icon}
@@ -224,7 +225,7 @@ const OurTeamSection = () => {
       </Typography>
       <Grid container spacing={2}>
         {degreeContent.map((item) => (
-          <Grid item xs={6} md={6} lg={4} key={item.label}>
+          <Grid item xs={12} md={6} lg={4} key={item.label}>
             <ListItemWithIcon
               sxProps={!isMediumOrSmallerScreen && { height: '56px' }}
               listIcon={!extraSmallScreen && item.icon}

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -211,10 +211,10 @@ const OurTeamSection = () => {
       </Typography>
       <Grid container spacing={2}>
         {experienceContent.map((item) => (
-          <Grid item xs={12} md={6} lg={4} key={item.label}>
+          <Grid item xs={12} sm={6} lg={4} key={item.label}>
             <ListItemWithIcon
               sxProps={!isMediumOrSmallerScreen && { height: '56px' }}
-              listIcon={!extraSmallScreen && item.icon}
+              listIcon={!isMediumOrSmallerScreen && item.icon}
               listText={item.label}
             />
           </Grid>
@@ -225,10 +225,10 @@ const OurTeamSection = () => {
       </Typography>
       <Grid container spacing={2}>
         {degreeContent.map((item) => (
-          <Grid item xs={12} md={6} lg={4} key={item.label}>
+          <Grid item xs={12} sm={6} lg={4} key={item.label}>
             <ListItemWithIcon
               sxProps={!isMediumOrSmallerScreen && { height: '56px' }}
-              listIcon={!extraSmallScreen && item.icon}
+              listIcon={!isMediumOrSmallerScreen && item.icon}
               listText={item.label}
             />
           </Grid>


### PR DESCRIPTION
## What

Slight edits to layout and cards to make it more readable on smaller devices. 

## Show Me

before:

<img src="https://github.com/openseattle/open-seattle-website/assets/60805050/20c2954d-c8b3-445a-8f94-ebd911a00802" width="425"/>

after:
<img src="https://github.com/openseattle/open-seattle-website/assets/60805050/8c8b20f7-b365-465e-ba07-7a6a89874e45" width="425"/>



