### PR TITLE
fix: Improve responsiveness of roles section

### DIFF
--- a/components/RolesSection.tsx
+++ b/components/RolesSection.tsx
@@ -145,7 +145,7 @@ const RoleListing = ({
   )
 }
 
-const RolesSection = ({ title, columns = 3, showLink = false, roles = [], children }: RolesSectionProps) => {
+const RolesSection = ({ title, showLink = false, roles = [], children }: RolesSectionProps) => {
   return (
     roles.length > 0 && (
       <Section>
@@ -154,9 +154,9 @@ const RolesSection = ({ title, columns = 3, showLink = false, roles = [], childr
           sx={{
             display: 'grid',
             gridAutoFlow: 'columns',
-            gridTemplateColumns: `repeat(${columns}, minmax(15rem, 1fr))`,
+            gridTemplateColumns: { xs: 'repeat(1), minmax(15rem, 1fr)', md: `repeat(2, minmax(15rem, 1fr))`, lg: 'repeat(3, minmax(15rem, 1fr))' },
             justifyContent: 'center',
-            gap: '2rem',
+            gap: { xs: '1rem', md: '2rem' },
             width: '100%',
           }}
         >


### PR DESCRIPTION
## What

Fix page responsiveness on the Volunteer, Cadre, and Individual Project pages. (addresses issue #6873 on airtable)

## Why Do

For improved formatting on mobile screens.

## How Do

I decided to change the grid behavior at three separate breakpoints:

- On Desktops the formatting remains as it was (three columns)
- On tablets/medium-sized screens the number of columns changes to two
- On mobile devices, the number of columns is reduced to one and the space between items in the column is decreased.


## Show Me

Mobile
![DAS-VolunteerPage_Mobile](https://github.com/openseattle/open-seattle-website/assets/49693755/bcd219de-6bb1-4a6e-873c-aa29195ee792)

Tablet
![DAS-VolunteerPage_Tablet](https://github.com/openseattle/open-seattle-website/assets/49693755/57053b8d-d51b-4abe-8038-f3417432a03b)

Desktop
![DAS-VolunteerPage_Desktop](https://github.com/openseattle/open-seattle-website/assets/49693755/8a48768f-0399-4ac0-add5-db6f61377d1a)


