### PR TITLE
fix: Handle empty photo on cadre team

### DIFF
--- a/pages/api/ProjectsService.ts
+++ b/pages/api/ProjectsService.ts
@@ -40,7 +40,7 @@ class DASProjectsService {
                 return {
                     name: `${r.fields["First name"]} ${r.fields["Last name"]}`,
                     role: r.fields["Position"],
-                    url: r.fields.pic[0].thumbnails.large.url
+                    url: r.fields.pic && r.fields.pic[0] && r.fields.pic[0].thumbnails.large.url || undefined
                 } as TeamMember
             });
     }


### PR DESCRIPTION
## What

Fix error created by missing team member photo on Cadre page

## Why Do

Missing photo created an error and prevented rendering the team members

## How Do

If a photo is not part of the object returned by air table, the service returns undefined.
In[ ProjectComponents.tsx](https://github.com/openseattle/open-seattle-website/blob/033205882fb6f7b3248a42d52f7ebfa6295ad700/components/ProjectComponents.tsx#L341), this undefined value is resolved with a placeholder image.
