### PR TITLE
Show role unavailable only if done loading

### DIFF
--- a/components/layouts.tsx
+++ b/components/layouts.tsx
@@ -71,6 +71,29 @@ export const withBasicLayout = (Page: () => JSX.Element) => () =>
     />
     <CommonHeader />
 
+    <MainContainer>
+      <Page />
+    </MainContainer>
+    <FooterContainer>
+      <CommonFooter />
+    </FooterContainer>
+  </>
+)
+
+export const withBasicLayoutLoading  = (Page: () => JSX.Element) => () =>
+(
+  <>
+    <CssBaseline />
+    <GlobalStyles
+      styles={{
+        a: {
+          color: 'inherit',
+          textDecoration: 'inherit',
+        },
+      }}
+    />
+    <CommonHeader />
+
     <WrappdMainContainer>
       <Page />
     </WrappdMainContainer>

--- a/components/layouts.tsx
+++ b/components/layouts.tsx
@@ -24,7 +24,7 @@ export const FooterContainer = styled.footer`
 `
 
 export const LoadingContext = createContext({
-  loading: false,
+  loading: true,
   setLoading: (b: boolean) => { },
 })
 
@@ -44,7 +44,7 @@ const LoadingIndicator = (): ReactJSXElement => {
 }
 
 const WrappdMainContainer = (props: { children: ReactNode }): ReactJSXElement => {
-  const [loading, setLoading] = useState(false)
+  const [loading, setLoading] = useState(true)
 
   return (
     <LoadingContext.Provider value={{ loading, setLoading }}>

--- a/components/layouts.tsx
+++ b/components/layouts.tsx
@@ -80,7 +80,8 @@ export const withBasicLayout = (Page: () => JSX.Element) => () =>
   </>
 )
 
-export const withBasicLayoutLoading  = (Page: () => JSX.Element) => () =>
+// eslint-disable-next-line react/display-name
+export const withBasicLayoutLoading = (Page: () => JSX.Element) => () =>
 (
   <>
     <CssBaseline />

--- a/pages/event.tsx
+++ b/pages/event.tsx
@@ -19,7 +19,7 @@ import {
 } from '@mui/material';
 import SectionContainer from 'components/layout/SectionContainer';
 
-import { LoadingContext, withBasicLayout } from 'components/layouts';
+import { LoadingContext, withBasicLayoutLoading } from 'components/layouts';
 // icons for role cards
 import EventAvailableOutlinedIcon from '@mui/icons-material/EventAvailableOutlined';
 import LocationOnIcon from '@mui/icons-material/LocationOn';
@@ -423,4 +423,4 @@ const EventPage = () => {
   )
 }
 
-export default withBasicLayout(EventPage)
+export default withBasicLayoutLoading(EventPage)

--- a/pages/events.tsx
+++ b/pages/events.tsx
@@ -10,7 +10,7 @@ import {
   useTheme
 } from '@mui/material'
 import CardEvent from 'components/cards/CardEvent'
-import { LoadingContext, withBasicLayout } from 'components/layouts'
+import { LoadingContext, withBasicLayoutLoading } from 'components/layouts'
 import { useContext, useEffect, useState } from 'react'
 
 import SectionContainer from 'components/layout/SectionContainer'
@@ -96,4 +96,4 @@ const EventsPage = () => {
   )
 }
 
-export default withBasicLayout(EventsPage)
+export default withBasicLayoutLoading(EventsPage)

--- a/pages/events.tsx
+++ b/pages/events.tsx
@@ -53,7 +53,7 @@ const EventsPage = () => {
   const theme = useTheme()
 
   const title = 'Events'
-  const { setLoading } = useContext(LoadingContext);
+  const { loading, setLoading } = useContext(LoadingContext);
   const [events, setEvents] = useState([])
 
   useEffect(() => {
@@ -83,7 +83,7 @@ const EventsPage = () => {
               <CardEvent key={event.title} event={event} />
             ))}
 
-            {events.length === 0 && (
+            {events.length === 0 && !loading && (
               <Typography sx={{ textAlign: 'center' }}>
                 All upcoming events are invite-only. Please check back in the
                 future for public events.

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,13 +4,12 @@ import { Box, Button, Stack, Typography, useTheme } from '@mui/material'
 import useMediaQuery from '@mui/material/useMediaQuery'
 import CardOne from 'components/cards/CardOne'
 import SectionContainer from 'components/layout/SectionContainer'
-import { withBasicLayout, LoadingContext } from 'components/layouts'
+import { withBasicLayout } from 'components/layouts'
 
 import CardGridContainer from 'components/cards/CardGridContainer'
 import HeroLines from '../public/images/homeHeroLines.svg'
 import HeroLinesMobile from '../public/images/homeHeroLinesMobile.svg'
 import HeroImage from '../public/images/SeattleSkyline.jpg'
-import { useContext, useEffect } from 'react'
 
 /* eslint-disable @next/next/no-img-element */
 
@@ -23,11 +22,6 @@ const Home = () => {
       quality || 75
     }`
   }
-
-  const { loading, setLoading } = useContext(LoadingContext);
-  useEffect(() => {
-    setLoading(false);
-  }, [])
 
   const isMediumScreen = useMediaQuery(theme.breakpoints.down('md'))
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,12 +4,13 @@ import { Box, Button, Stack, Typography, useTheme } from '@mui/material'
 import useMediaQuery from '@mui/material/useMediaQuery'
 import CardOne from 'components/cards/CardOne'
 import SectionContainer from 'components/layout/SectionContainer'
-import { withBasicLayout } from 'components/layouts'
+import { withBasicLayout, LoadingContext } from 'components/layouts'
 
 import CardGridContainer from 'components/cards/CardGridContainer'
 import HeroLines from '../public/images/homeHeroLines.svg'
 import HeroLinesMobile from '../public/images/homeHeroLinesMobile.svg'
 import HeroImage from '../public/images/SeattleSkyline.jpg'
+import { useContext, useEffect } from 'react'
 
 /* eslint-disable @next/next/no-img-element */
 
@@ -22,6 +23,11 @@ const Home = () => {
       quality || 75
     }`
   }
+
+  const { loading, setLoading } = useContext(LoadingContext);
+  useEffect(() => {
+    setLoading(false);
+  }, [])
 
   const isMediumScreen = useMediaQuery(theme.breakpoints.down('md'))
 

--- a/pages/project_individual.tsx
+++ b/pages/project_individual.tsx
@@ -12,7 +12,7 @@ import {
 } from '@mui/material'
 import SectionContainer from 'components/layout/SectionContainer'
 
-import { LoadingContext, withBasicLayout } from 'components/layouts'
+import { LoadingContext, withBasicLayoutLoading } from 'components/layouts'
 
 import { ProjectFooterSection, ProjectHeaderSection } from 'components/ProjectComponents'
 import RolesSection from 'components/RolesSection'
@@ -149,4 +149,4 @@ const ProjectIndividualPage = () => {
   )
 }
 
-export default withBasicLayout(ProjectIndividualPage)
+export default withBasicLayoutLoading(ProjectIndividualPage)

--- a/pages/projects.tsx
+++ b/pages/projects.tsx
@@ -2,7 +2,7 @@ import { Box, CircularProgress, Stack, useTheme } from '@mui/material'
 import Masthead from 'components/Masthead'
 import CardGridContainer from 'components/cards/CardGridContainer'
 import CardProject from 'components/cards/CardProject'
-import { LoadingContext, withBasicLayout } from 'components/layouts'
+import { LoadingContext, withBasicLayoutLoading } from 'components/layouts'
 import { useContext, useEffect, useState } from 'react'
 import { dasProjectsService } from './api/ProjectsService'
 
@@ -65,4 +65,4 @@ const ProjectsPage = () => {
   )
 }
 
-export default withBasicLayout(ProjectsPage)
+export default withBasicLayoutLoading(ProjectsPage)

--- a/pages/volunteer_role.tsx
+++ b/pages/volunteer_role.tsx
@@ -18,7 +18,7 @@ import { dasVolunteerRoleService } from './api/VolunteerRoleService'
 
 const VolunteerRolePage = () => {
   const [role, setRole] = useState<DASVolunteerRole>()
-  const { setLoading } = useContext(LoadingContext);
+  const { loading, setLoading } = useContext(LoadingContext);
 
   useEffect(() => {
     setLoading(true);
@@ -233,7 +233,7 @@ const VolunteerRolePage = () => {
               <RoleDescriptionSection roleData={role} />
             </>
           )}
-          {!role && <RoleUnavailableSection />}
+          {!role && !loading && <RoleUnavailableSection />}
         </Stack>
       </SectionContainer>
     </>

--- a/pages/volunteer_role.tsx
+++ b/pages/volunteer_role.tsx
@@ -9,7 +9,7 @@ import {
   useTheme
 } from '@mui/material'
 import SectionContainer from 'components/layout/SectionContainer'
-import { LoadingContext, withBasicLayout } from 'components/layouts'
+import { LoadingContext, withBasicLayoutLoading } from 'components/layouts'
 import Masthead from 'components/Masthead'
 import { useContext, useEffect, useState } from 'react'
 import { DASVolunteerRole } from 'types'
@@ -240,4 +240,4 @@ const VolunteerRolePage = () => {
   )
 }
 
-export default withBasicLayout(VolunteerRolePage)
+export default withBasicLayoutLoading(VolunteerRolePage)

--- a/pages/volunteers.tsx
+++ b/pages/volunteers.tsx
@@ -34,7 +34,7 @@ import MastheadWithImage from 'components/MastheadWithImage'
 import RolesSection from 'components/RolesSection'
 import CardOne from 'components/cards/CardOne'
 import SectionContainer from 'components/layout/SectionContainer'
-import { LoadingContext, withBasicLayout } from 'components/layouts'
+import { LoadingContext, withBasicLayoutLoading } from 'components/layouts'
 import { Section, Subheader } from 'components/style-utils'
 import Link from 'next/link'
 import React, { useContext, useEffect, useState } from 'react'
@@ -380,4 +380,4 @@ const VolunteerPage = () => {
   )
 }
 
-export default withBasicLayout(VolunteerPage)
+export default withBasicLayoutLoading(VolunteerPage)


### PR DESCRIPTION
## What

> Summary of what you're changing.

Very small fix that should remove the Role Unavailable text while a role page is loading. Addresses this [task](https://airtable.com/app6duHw2djMIOYnh/pagyirFMYPDku8npg?detail=eyJwYWdlSWQiOiJwYWd0WW5JcWkxc3VqQ2hNayIsInJvd0lkIjoicmVjYlBkNDdBYk5CTURSMzIiLCJzaG93Q29tbWVudHMiOmZhbHNlfQ)

## How Do

> Implementation choices, reviewer notes, caveats, etc.

I took the loading state from the context, and added that as a condition for rendering Role Unavailable. 