### PR TITLE
role page: parse qualifications into a list

### DIFF
--- a/pages/api/VolunteerRoleService.ts
+++ b/pages/api/VolunteerRoleService.ts
@@ -85,7 +85,7 @@ class DASVolunteerRoleService {
         whyJoin: getStringFieldRecord(record, 'Why Join Us'),
         aboutUs: getStringFieldRecord(record, 'About Us'),
         responsibilities: getSplitFieldRecord(record, 'Responsibilities'),
-        preferredQualifications: getStringFieldRecord(
+        preferredQualifications: getSplitFieldRecord(
           record,
           'Preferred Qualifications'
         ),

--- a/pages/volunteer_role.tsx
+++ b/pages/volunteer_role.tsx
@@ -172,7 +172,7 @@ const VolunteerRolePage = () => {
         {roleData.preferredQualifications ? (
           <RoleDescriptionSubSection
             title={'Preferred Qualifications'}
-            content={roleData.preferredQualifications.split(/\r?\n/g)}
+            content={roleData.preferredQualifications}
             list={true}
           />
         ) : null}

--- a/pages/volunteer_role.tsx
+++ b/pages/volunteer_role.tsx
@@ -46,14 +46,18 @@ const VolunteerRolePage = () => {
           paddingLeft: '1rem',
         }}
       >
-        {content.map((item: string, i) => (
-          <li
-            style={{ display: 'list-item', paddingLeft: '1rem', marginBottom: '1rem' }}
-            key={`${i}-${item}`}
-          >
-            {item}
-          </li>
-        ))}
+        {content.map((item: string, i) => {
+          const whiteSpaceOnlyRegex = /^\s*$/;
+          if (!item || whiteSpaceOnlyRegex.test(item)) { return; }
+          return (
+            <li
+              style={{ display: 'list-item', paddingLeft: '1rem', marginBottom: '1rem' }}
+              key={`${i}-${item}`}
+            >
+              {item}
+            </li>
+          )
+        })}
       </ul>
     )
   }

--- a/pages/volunteer_role.tsx
+++ b/pages/volunteer_role.tsx
@@ -36,7 +36,7 @@ const VolunteerRolePage = () => {
   }, [setLoading])
 
   const theme = useTheme()
-
+  
   const buildListItems = (content: string[]) => {
     return (
       <ul
@@ -172,8 +172,8 @@ const VolunteerRolePage = () => {
         {roleData.preferredQualifications ? (
           <RoleDescriptionSubSection
             title={'Preferred Qualifications'}
-            content={roleData.preferredQualifications}
-            list={false}
+            content={roleData.preferredQualifications.split(/\r?\n/g)}
+            list={true}
           />
         ) : null}
         {roleData.keyAttributesToSuccess ? (

--- a/types.d.ts
+++ b/types.d.ts
@@ -76,7 +76,7 @@ type DASVolunteerRole = {
   whyJoin: string
   aboutUs: string
   responsibilities: string[]
-  preferredQualifications: string
+  preferredQualifications: string[]
   keyAttributesToSuccess: string[]
   keyTechnologies?: string[]
   venture?: string


### PR DESCRIPTION
## What

> Summary of what you're changing.

simple change on the individual role pages, that presents the qualifications content as a list.

## Why Do

> The motivation behind your change.

address request from Seamus.

## How Do

> Implementation choices, reviewer notes, caveats, etc.
- this change simply splits the `preferredQualifications` into a string array on line breaks, which `RoleDescriptionSubSection` will use to render it as a list.
- we may want to use markdown in the future, as suggested by Jeff. 

## Show Me

> Screenshot of your change, if applicable.

![image](https://github.com/openseattle/open-seattle-website/assets/60805050/130e634f-badd-4009-902e-571200b06350)
