### PR TITLE
implement ux changes for project and event cards

### DIFF
--- a/components/cards/CardEvent.tsx
+++ b/components/cards/CardEvent.tsx
@@ -13,6 +13,7 @@ import useMediaQuery from '@mui/material/useMediaQuery'
 import { OSEvent } from 'types'
 import { urlForImage } from '../../sanity/lib/image'
 import { eventsService } from 'pages/api/EventsService'
+import { CardActionArea } from '@mui/material'
 
 type CardEventProps = {
   event: OSEvent
@@ -73,6 +74,7 @@ const CardEvent = ({ event }: CardEventProps) => {
             '0px 2px 4px 0px rgba(52, 61, 62, 0.04), 0px 4px 8px 2px rgba(52, 61, 62, 0.04)',
         }}
       >
+        <CardActionArea href={`/event?name=${event.id}`}>
         <Stack
           direction={{ xs: 'column', lg: 'row' }}
           spacing={{ xs: '0', lg: '1.5rem' }}
@@ -126,10 +128,10 @@ const CardEvent = ({ event }: CardEventProps) => {
               >
                 {event.description}
               </Typography>
-              {getButton()}
             </Stack>
           </CardContent>
         </Stack>
+        </CardActionArea>
       </Card>
     )
   } else {
@@ -141,6 +143,7 @@ const CardEvent = ({ event }: CardEventProps) => {
             '0px 2px 4px 0px rgba(52, 61, 62, 0.04), 0px 4px 8px 2px rgba(52, 61, 62, 0.04)',
         }}
       >
+        <CardActionArea href={`/event?name=${event.id}`}>
         <CardContent>
           <Stack direction="row">
             <Box
@@ -183,8 +186,8 @@ const CardEvent = ({ event }: CardEventProps) => {
           >
             {event.description}
           </Typography>
-          {getButton()}
         </CardContent>
+        </CardActionArea>
       </Card>
     )
   }

--- a/components/cards/CardEvent.tsx
+++ b/components/cards/CardEvent.tsx
@@ -21,61 +21,11 @@ type CardEventProps = {
 
 const CardEvent = ({ event }: CardEventProps) => {
   const theme = useTheme()
-  const mobileScreen = useMediaQuery(theme.breakpoints.down('md'))
-  const largeScreen = useMediaQuery(theme.breakpoints.up('lg'))
+  const tabletScreen = useMediaQuery(theme.breakpoints.only('md'))
 
-  const getButton = () => {
-    const buttonSX = (mobileScreen || largeScreen)
-      ? {
-        marginTop: { xs: '2rem', lg: '2.5rem' },
-        textAlign: 'center',
-        maxWidth: { xs: '100%', lg: 'min-content' },
-      }
-      : {
-        maxWidth: 'min-content',
-        display: 'block',
-        marginTop: '2rem',
-      }
-
-    if (event.details) {
-      return (
-        <Button
-          variant="contained"
-          sx={buttonSX}
-          href={`/event?name=${event.id}`}
-        >
-          Learn More
-        </Button>
-      )
-    }
-    else
-      if (event.rsvpLink) {
-        return (
-          <Button
-            variant="contained"
-            sx={buttonSX}
-            href={event.rsvpLink}
-          >
-            RVSP
-          </Button>
-        )
-      } else {
-        return (
-          <></>
-        )
-      }
-  }
-
-  if (mobileScreen || largeScreen) {
+  const MobileAndDesktopCard = () => {
     return (
-      <Card
-        sx={{
-          boxShadow:
-            '0px 2px 4px 0px rgba(52, 61, 62, 0.04), 0px 4px 8px 2px rgba(52, 61, 62, 0.04)',
-        }}
-      >
-        <CardActionArea href={`/event?name=${event.id}`}>
-        <Stack
+      <Stack
           direction={{ xs: 'column', lg: 'row' }}
           spacing={{ xs: '0', lg: '1.5rem' }}
         >
@@ -131,66 +81,68 @@ const CardEvent = ({ event }: CardEventProps) => {
             </Stack>
           </CardContent>
         </Stack>
-        </CardActionArea>
-      </Card>
-    )
-  } else {
-    // mediumScreen (tablet)
-    return (
-      <Card
-        sx={{
-          boxShadow:
-            '0px 2px 4px 0px rgba(52, 61, 62, 0.04), 0px 4px 8px 2px rgba(52, 61, 62, 0.04)',
-        }}
-      >
-        <CardActionArea href={`/event?name=${event.id}`}>
-        <CardContent>
-          <Stack direction="row">
-            <Box
-              sx={{
-                position: 'relative',
-                border: '2px solid #EAF1F1',
-                height: '10rem',
-                width: '10rem',
-              }}>
-              {event.image && event.image.asset &&
-                <CardMedia
-                  component="img"
-                  image={urlForImage(event.image).url()}
-                  sx={{
-                    position: 'static',
-                    height: '100%',
-                    borderRadius: '8px',
-                  }}
-                />
-              }
-            </Box>
-            <Stack
-              spacing="1rem"
-              justifyContent="center"
-              sx={{ marginLeft: '1.5rem' }}
-            >
-              <Typography variant="titleLarge">{event.title}</Typography>
-              <Stack direction="row" spacing="1rem">
-                <Typography variant="labelLarge">{event.date}</Typography>
-                <Typography variant="labelLarge">
-                  {eventsService.getTimeString(event)}
-                </Typography>
-              </Stack>
-              <Typography variant="labelMedium">{event.location}</Typography>
-            </Stack>
-          </Stack>
-          <Typography
-            variant="bodyMedium"
-            sx={{ display: 'block', marginTop: '1rem !important' }}
-          >
-            {event.description}
-          </Typography>
-        </CardContent>
-        </CardActionArea>
-      </Card>
     )
   }
+
+  const TabletCard = () => {
+    return (
+      <>
+      <Stack direction="row">
+        <Box
+          sx={{
+            position: 'relative',
+            border: '2px solid #EAF1F1',
+            height: '10rem',
+            width: '10rem',
+          }}>
+          {event.image && event.image.asset &&
+            <CardMedia
+              component="img"
+              image={urlForImage(event.image).url()}
+              sx={{
+                position: 'static',
+                height: '100%',
+                borderRadius: '8px',
+              }}
+            />
+          }
+        </Box>
+        <Stack
+          spacing="1rem"
+          justifyContent="center"
+          sx={{ marginLeft: '1.5rem' }}
+        >
+          <Typography variant="titleLarge">{event.title}</Typography>
+          <Stack direction="row" spacing="1rem">
+            <Typography variant="labelLarge">{event.date}</Typography>
+            <Typography variant="labelLarge">
+              {eventsService.getTimeString(event)}
+            </Typography>
+          </Stack>
+          <Typography variant="labelMedium">{event.location}</Typography>
+        </Stack>
+      </Stack>
+      <Typography
+        variant="bodyMedium"
+        sx={{ display: 'block', marginTop: '1rem !important' }}
+      >
+        {event.description}
+      </Typography>
+    </>
+    )
+  }
+
+  return (
+    <Card
+      sx={{
+        boxShadow:
+          '0px 2px 4px 0px rgba(52, 61, 62, 0.04), 0px 4px 8px 2px rgba(52, 61, 62, 0.04)',
+      }}
+    >
+      <CardActionArea href={`/event?name=${event.id}`}>
+      {tabletScreen ? <TabletCard /> : <MobileAndDesktopCard/>}
+      </CardActionArea>
+    </Card>)
 }
 
 export default CardEvent

--- a/components/cards/CardEvent.tsx
+++ b/components/cards/CardEvent.tsx
@@ -21,11 +21,11 @@ type CardEventProps = {
 
 const CardEvent = ({ event }: CardEventProps) => {
   const theme = useTheme()
-  const extraSmallScreen = useMediaQuery(theme.breakpoints.only('xs'))
+  const mobileScreen = useMediaQuery(theme.breakpoints.down('md'))
   const largeScreen = useMediaQuery(theme.breakpoints.up('lg'))
 
   const getButton = () => {
-    const buttonSX = (extraSmallScreen || largeScreen)
+    const buttonSX = (mobileScreen || largeScreen)
       ? {
         marginTop: { xs: '2rem', lg: '2.5rem' },
         textAlign: 'center',
@@ -66,7 +66,7 @@ const CardEvent = ({ event }: CardEventProps) => {
       }
   }
 
-  if (extraSmallScreen || largeScreen) {
+  if (mobileScreen || largeScreen) {
     return (
       <Card
         sx={{

--- a/components/cards/CardEvent.tsx
+++ b/components/cards/CardEvent.tsx
@@ -2,7 +2,6 @@
  * @2024 Digital Aid Seattle
  */
 import Box from '@mui/material/Box'
-import Button from '@mui/material/Button'
 import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'
 import CardMedia from '@mui/material/CardMedia'
@@ -26,109 +25,110 @@ const CardEvent = ({ event }: CardEventProps) => {
   const MobileAndDesktopCard = () => {
     return (
       <Stack
-          direction={{ xs: 'column', lg: 'row' }}
-          spacing={{ xs: '0', lg: '1.5rem' }}
+        direction={{ xs: 'column', lg: 'row' }}
+        spacing={{ xs: '0', lg: '1.5rem' }}
+      >
+        <Box
+          sx={{
+            position: 'relative',
+            border: '2px solid #EAF1F1',
+            height: { xs: '0', lg: '20rem' },
+            width: { xs: '100%', lg: '20rem' },
+            paddingBottom: { xs: '100%', lg: '0' },
+            flexShrink: '0',
+            margin: { xs: '0', lg: '2rem 0 2rem 2rem' },
+            minWidth: '0',
+            borderRadius: '8px',
+            overflow: 'hidden',
+          }}
         >
-          <Box
-            sx={{
-              position: 'relative',
-              border: '2px solid #EAF1F1',
-              height: { xs: '0', lg: '20rem' },
-              width: { xs: '100%', lg: '20rem' },
-              paddingBottom: { xs: '100%', lg: '0' },
-              flexShrink: '0',
-              margin: { xs: '0', lg: '2rem 0 2rem 2rem' },
-              minWidth: '0',
-              borderRadius: '8px',
-              overflow: 'hidden',
-            }}
-          >
-            {event.image && event.image.asset &&
-              <CardMedia
-                component="img"
-                image={urlForImage(event.image).url()}
-                sx={{
-                  position: { xs: 'absolute', lg: 'static' },
-                  height: '100%',
-                }}
-              />
-            }
-          </Box>
-          <CardContent
-            sx={{
-              padding: { xs: '2rem 1rem 1rem 1rem', lg: '2rem 2rem 2rem 0' },
-              paddingBottom: { xs: '1rem !important', lg: '2rem !important' },
-            }}
-          >
-            <Stack justifyContent="center" sx={{ height: '100%' }}>
-              <Stack spacing="1rem">
-                <Typography variant="titleLarge">{event.title}</Typography>
-                <Stack direction="row" spacing="1rem">
-                  <Typography variant="labelLarge">{event.date}</Typography>
-                  <Typography variant="labelLarge">
-                    {eventsService.getTimeString(event)}
-                  </Typography>
-                </Stack>
-                <Typography variant="labelMedium">{event.location}</Typography>
+          {event.image && event.image.asset && (
+            <CardMedia
+              component="img"
+              image={urlForImage(event.image).url()}
+              sx={{
+                position: { xs: 'absolute', lg: 'static' },
+                height: '100%',
+              }}
+            />
+          )}
+        </Box>
+        <CardContent
+          sx={{
+            padding: { xs: '2rem 1rem 1rem 1rem', lg: '2rem 2rem 2rem 0' },
+            paddingBottom: { xs: '1rem !important', lg: '2rem !important' },
+          }}
+        >
+          <Stack justifyContent="center" sx={{ height: '100%' }}>
+            <Stack spacing="1rem">
+              <Typography variant="titleLarge">{event.title}</Typography>
+              <Stack direction="row" spacing="1rem">
+                <Typography variant="labelLarge">{event.date}</Typography>
+                <Typography variant="labelLarge">
+                  {eventsService.getTimeString(event)}
+                </Typography>
               </Stack>
-
-              <Typography
-                variant="bodyMedium"
-                sx={{ display: 'block', marginTop: '1.5rem' }}
-              >
-                {event.description}
-              </Typography>
+              <Typography variant="labelMedium">{event.location}</Typography>
             </Stack>
-          </CardContent>
-        </Stack>
+
+            <Typography
+              variant="bodyMedium"
+              sx={{ display: 'block', marginTop: '1.5rem' }}
+            >
+              {event.description}
+            </Typography>
+          </Stack>
+        </CardContent>
+      </Stack>
     )
   }
 
   const TabletCard = () => {
     return (
-      <>
-      <Stack direction="row">
-        <Box
-          sx={{
-            position: 'relative',
-            border: '2px solid #EAF1F1',
-            height: '10rem',
-            width: '10rem',
-          }}>
-          {event.image && event.image.asset &&
-            <CardMedia
-              component="img"
-              image={urlForImage(event.image).url()}
-              sx={{
-                position: 'static',
-                height: '100%',
-                borderRadius: '8px',
-              }}
-            />
-          }
-        </Box>
-        <Stack
-          spacing="1rem"
-          justifyContent="center"
-          sx={{ marginLeft: '1.5rem' }}
-        >
-          <Typography variant="titleLarge">{event.title}</Typography>
-          <Stack direction="row" spacing="1rem">
-            <Typography variant="labelLarge">{event.date}</Typography>
-            <Typography variant="labelLarge">
-              {eventsService.getTimeString(event)}
-            </Typography>
+      <CardContent>
+        <Stack direction="row">
+          <Box
+            sx={{
+              position: 'relative',
+              border: '2px solid #EAF1F1',
+              height: '10rem',
+              width: '10rem',
+            }}
+          >
+            {event.image && event.image.asset && (
+              <CardMedia
+                component="img"
+                image={urlForImage(event.image).url()}
+                sx={{
+                  position: 'static',
+                  height: '100%',
+                  borderRadius: '8px',
+                }}
+              />
+            )}
+          </Box>
+          <Stack
+            spacing="1rem"
+            justifyContent="center"
+            sx={{ marginLeft: '1.5rem' }}
+          >
+            <Typography variant="titleLarge">{event.title}</Typography>
+            <Stack direction="row" spacing="1rem">
+              <Typography variant="labelLarge">{event.date}</Typography>
+              <Typography variant="labelLarge">
+                {eventsService.getTimeString(event)}
+              </Typography>
+            </Stack>
+            <Typography variant="labelMedium">{event.location}</Typography>
           </Stack>
-          <Typography variant="labelMedium">{event.location}</Typography>
         </Stack>
-      </Stack>
-      <Typography
-        variant="bodyMedium"
-        sx={{ display: 'block', marginTop: '1rem !important' }}
-      >
-        {event.description}
-      </Typography>
-    </>
+        <Typography
+          variant="bodyMedium"
+          sx={{ display: 'block', marginTop: '1rem !important' }}
+        >
+          {event.description}
+        </Typography>
+      </CardContent>
     )
   }
 
@@ -140,9 +140,10 @@ const CardEvent = ({ event }: CardEventProps) => {
       }}
     >
       <CardActionArea href={`/event?name=${event.id}`}>
-      {tabletScreen ? <TabletCard /> : <MobileAndDesktopCard/>}
+        {tabletScreen ? <TabletCard /> : <MobileAndDesktopCard />}
       </CardActionArea>
-    </Card>)
+    </Card>
+  )
 }
 
 export default CardEvent

--- a/components/cards/CardProject.tsx
+++ b/components/cards/CardProject.tsx
@@ -44,43 +44,32 @@ const CardProject = ({ project }: CardProjectProps) => {
               display: { xs: 'none', md: 'block' },
             }}
           />
-          <Stack spacing="1rem">
+          <Stack spacing="1rem" sx={{width:'100%'}}>
             <Typography variant="titleLarge" component="h2">
               {project.title}
             </Typography>
-            <Typography variant="labelLarge">{project.partner}</Typography>
-            <Typography variant="labelMedium">
-              {(project.programAreas ? project.programAreas : []).join(', ')}
-            </Typography>
+            <Stack spacing="1rem">
+                <Stack
+                  direction="row"
+                  justifyContent="space-between"
+                  alignItems="center">
+                  <Typography variant="labelLarge">{project.partner}</Typography>
+                  <StateBadge state={project.status} />
+                </Stack>
+                <Stack
+                  direction="row"
+                  justifyContent="space-between">
+                  <Typography variant="labelMedium">
+                    {(project.programAreas ? project.programAreas : []).join(', ')}
+                  </Typography>
+                  <Typography variant="labelMedium">
+                    {dasProjectsService.getTimeline(project)}
+                  </Typography>
+                </Stack>
+            </Stack>
           </Stack>
         </Stack>
         <Typography variant="bodyMedium">{project.description}</Typography>
-        <Stack
-          direction={{ xs: 'column-reverse', lg: 'row' }}
-          alignItems={{ xs: 'auto', lg: 'flex-end' }}
-          justifyContent="space-between"
-          spacing="1rem"
-        >
-          <Button
-            variant="contained"
-            href={project.projectLink}
-            sx={{ width: { md: 'max-content' } }}
-          >
-            View Project
-          </Button>
-          <Stack
-            direction={{ xs: 'row-reverse', lg: 'column' }}
-            justifyContent={{ xs: 'space-between', sm: 'auto' }}
-            alignItems={{ xs: 'center', sm: 'auto' }}
-            spacing="1rem"
-          >
-            <StateBadge state={project.status} />
-
-            <Typography variant="labelMedium">
-              {dasProjectsService.getTimeline(project)}
-            </Typography>
-          </Stack>
-        </Stack>
       </CardContent>
     </Card>
   )

--- a/components/cards/CardProject.tsx
+++ b/components/cards/CardProject.tsx
@@ -22,9 +22,7 @@ const CardProject = ({ project }: CardProjectProps) => {
           '0px 2px 4px 0px rgba(52, 61, 62, 0.04), 0px 4px 8px 2px rgba(52, 61, 62, 0.04)',
       }}
     >
-      <CardActionArea 
-        href={project.projectLink}
-        sx={{ height: '100%' }}>
+      <CardActionArea href={project.projectLink} sx={{ height: '100%' }}>
         <CardContent
           sx={{
             padding: { xs: '2rem 1rem', lg: '2rem' },
@@ -46,28 +44,31 @@ const CardProject = ({ project }: CardProjectProps) => {
                 display: { xs: 'none', md: 'block' },
               }}
             />
-            <Stack spacing="1rem" sx={{width:'100%'}}>
+            <Stack spacing="1rem" sx={{ width: '100%' }}>
               <Typography variant="titleLarge" component="h2">
                 {project.title}
               </Typography>
               <Stack spacing="1rem">
-                  <Stack
-                    direction="row"
-                    justifyContent="space-between"
-                    alignItems="center">
-                    <Typography variant="labelLarge">{project.partner}</Typography>
-                    <StateBadge state={project.status} />
-                  </Stack>
-                  <Stack
-                    direction="row"
-                    justifyContent="space-between">
-                    <Typography variant="labelMedium">
-                      {(project.programAreas ? project.programAreas : []).join(', ')}
-                    </Typography>
-                    <Typography variant="labelMedium">
-                      {dasProjectsService.getTimeline(project)}
-                    </Typography>
-                  </Stack>
+                <Stack
+                  direction="row"
+                  justifyContent="space-between"
+                  alignItems="center"
+                >
+                  <Typography variant="labelLarge">
+                    {project.partner}
+                  </Typography>
+                  <StateBadge state={project.status} />
+                </Stack>
+                <Stack direction="row" justifyContent="space-between">
+                  <Typography variant="labelMedium">
+                    {(project.programAreas ? project.programAreas : []).join(
+                      ', '
+                    )}
+                  </Typography>
+                  <Typography variant="labelMedium">
+                    {dasProjectsService.getTimeline(project)}
+                  </Typography>
+                </Stack>
               </Stack>
             </Stack>
           </Stack>

--- a/components/cards/CardProject.tsx
+++ b/components/cards/CardProject.tsx
@@ -1,4 +1,3 @@
-import Button from '@mui/material/Button'
 import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'
 import CardMedia from '@mui/material/CardMedia'
@@ -9,6 +8,7 @@ import { dasProjectsService } from 'pages/api/ProjectsService'
 import { DASProject } from 'types'
 import { urlForImage } from '../../sanity/lib/image'
 import StateBadge from './StateBadge'
+import { CardActionArea } from '@mui/material'
 
 type CardProjectProps = {
   project: DASProject
@@ -22,55 +22,58 @@ const CardProject = ({ project }: CardProjectProps) => {
           '0px 2px 4px 0px rgba(52, 61, 62, 0.04), 0px 4px 8px 2px rgba(52, 61, 62, 0.04)',
       }}
     >
-      <CardContent
-        sx={{
-          padding: { xs: '2rem 1rem', lg: '2rem' },
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '1.5rem',
-          justifyContent: 'space-between',
-          height: '100%',
-        }}
-      >
-        <Stack direction={{ xs: 'row', lg: 'column' }} gap="1.5rem">
-          <CardMedia
-            component="img"
-            image={urlForImage(project.image).url()}
-            sx={{
-              width: { md: '7rem', lg: '100%' },
-              aspectRatio: '1 / 1',
-              border: '2px solid #EAF1F1',
-              borderRadius: '8px',
-              display: { xs: 'none', md: 'block' },
-            }}
-          />
-          <Stack spacing="1rem" sx={{width:'100%'}}>
-            <Typography variant="titleLarge" component="h2">
-              {project.title}
-            </Typography>
-            <Stack spacing="1rem">
-                <Stack
-                  direction="row"
-                  justifyContent="space-between"
-                  alignItems="center">
-                  <Typography variant="labelLarge">{project.partner}</Typography>
-                  <StateBadge state={project.status} />
-                </Stack>
-                <Stack
-                  direction="row"
-                  justifyContent="space-between">
-                  <Typography variant="labelMedium">
-                    {(project.programAreas ? project.programAreas : []).join(', ')}
-                  </Typography>
-                  <Typography variant="labelMedium">
-                    {dasProjectsService.getTimeline(project)}
-                  </Typography>
-                </Stack>
+      <CardActionArea 
+        href={project.projectLink}
+        sx={{ height: '100%' }}>
+        <CardContent
+          sx={{
+            padding: { xs: '2rem 1rem', lg: '2rem' },
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '1.5rem',
+            justifyContent: 'space-between',
+          }}
+        >
+          <Stack direction={{ xs: 'row', lg: 'column' }} gap="1.5rem">
+            <CardMedia
+              component="img"
+              image={urlForImage(project.image).url()}
+              sx={{
+                width: { md: '7rem', lg: '100%' },
+                aspectRatio: '1 / 1',
+                border: '2px solid #EAF1F1',
+                borderRadius: '8px',
+                display: { xs: 'none', md: 'block' },
+              }}
+            />
+            <Stack spacing="1rem" sx={{width:'100%'}}>
+              <Typography variant="titleLarge" component="h2">
+                {project.title}
+              </Typography>
+              <Stack spacing="1rem">
+                  <Stack
+                    direction="row"
+                    justifyContent="space-between"
+                    alignItems="center">
+                    <Typography variant="labelLarge">{project.partner}</Typography>
+                    <StateBadge state={project.status} />
+                  </Stack>
+                  <Stack
+                    direction="row"
+                    justifyContent="space-between">
+                    <Typography variant="labelMedium">
+                      {(project.programAreas ? project.programAreas : []).join(', ')}
+                    </Typography>
+                    <Typography variant="labelMedium">
+                      {dasProjectsService.getTimeline(project)}
+                    </Typography>
+                  </Stack>
+              </Stack>
             </Stack>
           </Stack>
-        </Stack>
-        <Typography variant="bodyMedium">{project.description}</Typography>
-      </CardContent>
+          <Typography variant="bodyMedium">{project.description}</Typography>
+        </CardContent>
+      </CardActionArea>
     </Card>
   )
 }


### PR DESCRIPTION
## What

> Summary of what you're changing.

- Addressing Grace's design edits ([figma link](https://www.figma.com/file/vs1l6ERmi4AqYjxBBK9gDJ/Style-Guide-%26-Prototypes?node-id=1114%3A39079&mode=dev)), where the action buttons on the project and event cards are removed, and the whole card is made clickable.
- Also fixed the mobile breakpoint on the event cards, and refactored a bit there

## How Do

> Implementation choices, reviewer notes, caveats, etc.

Used [CardActionArea](https://mui.com/material-ui/react-card/#primary-action) from MUI to make the card clickable. I like the built-in hover effect!

Bummed that I couldn't make the cards keyboard accessible, would like to figure that out. Adding `tabIndex` or even wrapping the whole card with a link did not work :/

## Show Me

> Screenshot of your change, if applicable.
![image](https://github.com/openseattle/open-seattle-website/assets/60805050/138c8659-1d5c-458d-a972-7c21efdfc189)
![image](https://github.com/openseattle/open-seattle-website/assets/60805050/986592dc-0c90-4f78-b312-cafbc2519c1b)

