### PR TITLE
mobile slide-out menu

### DIFF
--- a/components/CommonHeader.tsx
+++ b/components/CommonHeader.tsx
@@ -15,6 +15,7 @@ import Toolbar from '@mui/material/Toolbar'
 import { useRouter } from 'next/router'
 import * as React from 'react'
 import { theme } from 'theme/theme'
+import MobileMenu from './MobileMenu'
 
 import OSLogo from '../assets/darkThemeLogo.svg'
 
@@ -49,6 +50,8 @@ const CommonHeader = () => {
   const handleCloseNavMenu = () => {
     setAnchorElNav(null)
   }
+
+  const [showMobileMenu, setShowMobileMenu] = React.useState(false);
 
   const router = useRouter()
 
@@ -93,12 +96,12 @@ const CommonHeader = () => {
             aria-label="page-info"
             aria-controls="menu-appbar"
             aria-haspopup="true"
-            onClick={handleOpenNavMenu}
+            onClick={()=>setShowMobileMenu(!showMobileMenu)}
             sx={{ color: theme.palette.primary.contrastText }}
           >
             <MenuIcon />
           </IconButton>
-          <Menu
+          {/* <Menu
             id="menu-appbar"
             anchorEl={anchorElNav}
             anchorOrigin={{
@@ -114,26 +117,9 @@ const CommonHeader = () => {
             onClose={handleCloseNavMenu}
             sx={{
               display: { xs: 'block', lg: 'none' },
-            }}
-          >
-            {Object.keys(SECTION_TO_PATH).map((name) => (
-              <MenuItem
-                key={name}
-                onClick={handleCloseNavMenu}
-                style={{ borderRadius: '0px' }}
-              >
-                <Link
-                  underline="hover"
-                  sx={{
-                    color: theme.palette.primary.dark,
-                  }}
-                  href={SECTION_TO_PATH[name]}
-                >
-                  {name}
-                </Link>
-              </MenuItem>
-            ))}
-          </Menu>
+              width: '100vw',
+              backgroundColor: 'red'
+            }} */}
         </Box>
         {/* Menu items that are shown on desktop */}
         <Container
@@ -186,6 +172,26 @@ const CommonHeader = () => {
           </nav>
         </Container>
       </Toolbar>
+      {showMobileMenu && 
+        <MobileMenu> 
+            {Object.keys(SECTION_TO_PATH).map((name) => (
+              <MenuItem
+                key={name}
+                onClick={handleCloseNavMenu}
+                style={{ borderRadius: '0px' }}
+              >
+                <Link
+                  underline="hover"
+                  sx={{
+                    color: theme.palette.primary.dark,
+                  }}
+                  href={SECTION_TO_PATH[name]}
+                >
+                  {name}
+                </Link>
+              </MenuItem>
+            ))}
+          </MobileMenu>}
     </AppBar>
   )
 }

--- a/components/CommonHeader.tsx
+++ b/components/CommonHeader.tsx
@@ -4,6 +4,7 @@
 /* eslint-disable jsx-a11y/alt-text  */
 /* eslint-disable @next/next/no-img-element */
 import MenuIcon from '@mui/icons-material/Menu'
+import CloseIcon from '@mui/icons-material/Close'
 import { Box, Button, Typography } from '@mui/material'
 import AppBar from '@mui/material/AppBar'
 import Container from '@mui/material/Container'
@@ -100,27 +101,8 @@ const CommonHeader = () => {
             onClick={()=>setShowMobileMenu(!showMobileMenu)}
             sx={{ color: theme.palette.primary.contrastText }}
           >
-            <MenuIcon />
+            {showMobileMenu ? <CloseIcon /> : <MenuIcon />}
           </IconButton>
-          {/* <Menu
-            id="menu-appbar"
-            anchorEl={anchorElNav}
-            anchorOrigin={{
-              vertical: 'bottom',
-              horizontal: 'left',
-            }}
-            keepMounted
-            transformOrigin={{
-              vertical: 'top',
-              horizontal: 'left',
-            }}
-            open={Boolean(anchorElNav)}
-            onClose={handleCloseNavMenu}
-            sx={{
-              display: { xs: 'block', lg: 'none' },
-              width: '100vw',
-              backgroundColor: 'red'
-            }} */}
         </Box>
         {/* Menu items that are shown on desktop */}
         <Container

--- a/components/CommonHeader.tsx
+++ b/components/CommonHeader.tsx
@@ -3,8 +3,8 @@
  */
 /* eslint-disable jsx-a11y/alt-text  */
 /* eslint-disable @next/next/no-img-element */
-import MenuIcon from '@mui/icons-material/Menu'
 import CloseIcon from '@mui/icons-material/Close'
+import MenuIcon from '@mui/icons-material/Menu'
 import { Box, Button, Typography } from '@mui/material'
 import AppBar from '@mui/material/AppBar'
 import Container from '@mui/material/Container'
@@ -15,9 +15,9 @@ import Toolbar from '@mui/material/Toolbar'
 import { useRouter } from 'next/router'
 import * as React from 'react'
 import { theme } from 'theme/theme'
-import MobileMenu from './MobileMenu'
 
 import OSLogo from '../assets/darkThemeLogo.svg'
+import MobileMenu from './MobileMenu'
 
 const SECTION_TO_PATH = {
   About: '/about',
@@ -60,101 +60,104 @@ const CommonHeader = () => {
   }
 
   return (
-    <AppBar
-      position="sticky"
-      elevation={0}
-      sx={{
-        background: theme.palette.primary.main,
-      }}
-    >
-      <Box sx={{position: 'relative'}}>
-      <Toolbar sx={{ padding: '0 !important' }}>
-        <Box
-          sx={{
-            flexGrow: 1,
-            display: { xs: 'flex', lg: 'none' },
-            justifyContent: 'space-between',
-            padding: {
-              xs: '1rem 1rem',
-              md: '1rem 2rem',
-              lg: '1.25rem 0',
-            },
-          }}
-        >
-          {/* Hamburger menu when the screen is small. */}
-          {/* LOGO */}
-          <Link href="/">
-            <img
-              src={OSLogo.src}
-              style={{
-                width: '120px',
-              }}
-              alt="Digital Aid Seattle Home"
-            />
-          </Link>
-          <IconButton
-            size="large"
-            aria-label="page-info"
-            aria-controls="menu-appbar"
-            aria-haspopup="true"
-            onClick={()=>setShowMobileMenu(!showMobileMenu)}
-            sx={{ color: theme.palette.primary.contrastText }}
+    // Containing Box is given AppBar's z-index; ensures it always stays on top.
+    // MUI z-index reference: https://mui.com/material-ui/customization/z-index/
+    <Box sx={{ position: 'sticky', top: 0, zIndex: 1100 }}>
+      <AppBar
+        position="static"
+        elevation={0}
+        sx={{
+          background: theme.palette.primary.main,
+        }}
+      >
+        <Toolbar sx={{ padding: '0 !important' }}>
+          <Box
+            sx={{
+              flexGrow: 1,
+              display: { xs: 'flex', lg: 'none' },
+              justifyContent: 'space-between',
+              padding: {
+                xs: '1rem 1rem',
+                md: '1rem 2rem',
+                lg: '1.25rem 0',
+              },
+            }}
           >
-            {showMobileMenu ? <CloseIcon /> : <MenuIcon />}
-          </IconButton>
-        </Box>
-        {/* Menu items that are shown on desktop */}
-        <Container
-          disableGutters
-          sx={{
-            flexGrow: 1,
-            display: { xs: 'none', md: 'none', lg: 'flex' },
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            padding: '1.25rem 2.5rem !important',
-          }}
-        >
-          {/* LOGO */}
-          <Link href="/">
-            <img
-              src={OSLogo.src}
-              style={{
-                width: '120px',
-              }}
-              alt="Digital Aid Seattle Home"
-            />
-          </Link>
-          <nav>
-            <ul>
-              {Object.keys(SECTION_TO_PATH).map((name) => (
-                <Button
-                  key={name}
-                  onClick={handleCloseNavMenu}
-                  variant="contained"
-                  color={isCurrent(name)
-                    ? 'success'
-                    : 'primary'}
-                  disableRipple={true}
-                >
-                  <Link
-                    sx={{
-                      color: theme.palette.primary.contrastText,
-                      textUnderlineOffset: '0.5rem',
-                      textDecoration: isCurrent(name)
-                        ? 'underline'
-                        : 'none'
-                    }}
-                    href={SECTION_TO_PATH[name]}
+            {/* Hamburger menu when the screen is small. */}
+            {/* LOGO */}
+            <Link href="/">
+              <img
+                src={OSLogo.src}
+                style={{
+                  width: '120px',
+                }}
+                alt="Digital Aid Seattle Home"
+              />
+            </Link>
+            <IconButton
+              size="large"
+              aria-label="page-info"
+              aria-controls="menu-appbar"
+              aria-haspopup="true"
+              onClick={()=>setShowMobileMenu(!showMobileMenu)}
+              sx={{ color: theme.palette.primary.contrastText }}
+            >
+              {showMobileMenu ? <CloseIcon /> : <MenuIcon />}
+            </IconButton>
+          </Box>
+          {/* Menu items that are shown on desktop */}
+          <Container
+            disableGutters
+            sx={{
+              flexGrow: 1,
+              display: { xs: 'none', md: 'none', lg: 'flex' },
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              padding: '1.25rem 2.5rem !important',
+            }}
+          >
+            {/* LOGO */}
+            <Link href="/">
+              <img
+                src={OSLogo.src}
+                style={{
+                  width: '120px',
+                }}
+                alt="Digital Aid Seattle Home"
+              />
+            </Link>
+            <nav>
+              <ul>
+                {Object.keys(SECTION_TO_PATH).map((name) => (
+                  <Button
+                    key={name}
+                    onClick={handleCloseNavMenu}
+                    variant="contained"
+                    color={isCurrent(name)
+                      ? 'success'
+                      : 'primary'}
+                    disableRipple={true}
                   >
-                    {name}
-                  </Link>
-                </Button>
-              ))}
-            </ul>
-          </nav>
-        </Container>
-      </Toolbar>
-      {
+                    <Link
+                      sx={{
+                        color: theme.palette.primary.contrastText,
+                        textUnderlineOffset: '0.5rem',
+                        textDecoration: isCurrent(name)
+                          ? 'underline'
+                          : 'none'
+                      }}
+                      href={SECTION_TO_PATH[name]}
+                    >
+                      {name}
+                    </Link>
+                  </Button>
+                ))}
+              </ul>
+            </nav>
+          </Container>
+        </Toolbar>
+      </AppBar>
+      <Box sx={{ position: 'relative', zIndex: -1 }}>
         <MobileMenu yTranslate={showMobileMenu ? '0' : '-500px'}> 
             {Object.keys(SECTION_TO_PATH).map((name) => (
               <MenuItem
@@ -175,9 +178,9 @@ const CommonHeader = () => {
                 </Link>
               </MenuItem>
             ))}
-          </MobileMenu>}
-          </Box>
-    </AppBar>
+          </MobileMenu>
+      </Box>
+    </Box>
   )
 }
 export default CommonHeader

--- a/components/CommonHeader.tsx
+++ b/components/CommonHeader.tsx
@@ -13,7 +13,7 @@ import Link from '@mui/material/Link'
 import MenuItem from '@mui/material/MenuItem'
 import Toolbar from '@mui/material/Toolbar'
 import { useRouter } from 'next/router'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { theme } from 'theme/theme'
 
 import OSLogo from '../assets/darkThemeLogo.svg'
@@ -40,17 +40,7 @@ const PATH_TO_SECTION = {
 
 
 const CommonHeader = () => {
-  // React states and functions for handling the hamburger menu.
-  const [anchorElNav, setAnchorElNav] = useState<null | HTMLElement>(null)
-
-  const handleOpenNavMenu = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorElNav(event.currentTarget)
-  }
-
-  const handleCloseNavMenu = () => {
-    setAnchorElNav(null)
-  }
-
+  // React states for handling the hamburger menu.
   const [showMobileMenu, setShowMobileMenu] = useState(false);
   const smallScreen = useMediaQuery(theme.breakpoints.down('lg'))
 
@@ -62,7 +52,7 @@ const CommonHeader = () => {
 
   return (
     // Containing Box is given AppBar's z-index; ensures it always stays on top.
-    // MUI z-index reference: https://mui.com/material-ui/customization/z-index/
+    // z-index taken from docs: https://mui.com/material-ui/customization/z-index/
     <Box sx={{ position: 'sticky', top: 0, zIndex: 1100 }}>
       <AppBar
         position="static"
@@ -132,7 +122,6 @@ const CommonHeader = () => {
                 {Object.keys(SECTION_TO_PATH).map((name) => (
                   <Button
                     key={name}
-                    onClick={handleCloseNavMenu}
                     variant="contained"
                     color={isCurrent(name)
                       ? 'success'
@@ -158,14 +147,13 @@ const CommonHeader = () => {
           </Container>
         </Toolbar>
       </AppBar>
-      {/* the mobile slide-out menu */}
+      {/* mobile slide-out menu */}
       {smallScreen &&
       <Box sx={{ position: 'relative', zIndex: -1 }}>
         <MobileMenu yTranslate={showMobileMenu ? '0' : '-500px'}> 
             {Object.keys(SECTION_TO_PATH).map((name) => (
               <MenuItem
                 key={name}
-                onClick={handleCloseNavMenu}
                 style={{ borderRadius: '0px' }}
               >
                 <Link

--- a/components/CommonHeader.tsx
+++ b/components/CommonHeader.tsx
@@ -4,7 +4,7 @@
 /* eslint-disable jsx-a11y/alt-text  */
 /* eslint-disable @next/next/no-img-element */
 import MenuIcon from '@mui/icons-material/Menu'
-import { Box, Button } from '@mui/material'
+import { Box, Button, Typography } from '@mui/material'
 import AppBar from '@mui/material/AppBar'
 import Container from '@mui/material/Container'
 import IconButton from '@mui/material/IconButton'
@@ -67,6 +67,7 @@ const CommonHeader = () => {
         background: theme.palette.primary.main,
       }}
     >
+      <Box sx={{position: 'relative'}}>
       <Toolbar sx={{ padding: '0 !important' }}>
         <Box
           sx={{
@@ -183,15 +184,18 @@ const CommonHeader = () => {
                 <Link
                   underline="hover"
                   sx={{
-                    color: theme.palette.primary.dark,
+                    color: theme.palette.primary.contrastText,
                   }}
                   href={SECTION_TO_PATH[name]}
                 >
-                  {name}
+                  <Typography variant="labelLarge">
+                    {name}
+                  </Typography>
                 </Link>
               </MenuItem>
             ))}
           </MobileMenu>}
+          </Box>
     </AppBar>
   )
 }

--- a/components/CommonHeader.tsx
+++ b/components/CommonHeader.tsx
@@ -10,7 +10,6 @@ import AppBar from '@mui/material/AppBar'
 import Container from '@mui/material/Container'
 import IconButton from '@mui/material/IconButton'
 import Link from '@mui/material/Link'
-import Menu from '@mui/material/Menu'
 import MenuItem from '@mui/material/MenuItem'
 import Toolbar from '@mui/material/Toolbar'
 import { useRouter } from 'next/router'
@@ -155,8 +154,8 @@ const CommonHeader = () => {
           </nav>
         </Container>
       </Toolbar>
-      {showMobileMenu && 
-        <MobileMenu> 
+      {
+        <MobileMenu yTranslate={showMobileMenu ? '0' : '-500px'}> 
             {Object.keys(SECTION_TO_PATH).map((name) => (
               <MenuItem
                 key={name}

--- a/components/CommonHeader.tsx
+++ b/components/CommonHeader.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @next/next/no-img-element */
 import CloseIcon from '@mui/icons-material/Close'
 import MenuIcon from '@mui/icons-material/Menu'
-import { Box, Button, Typography } from '@mui/material'
+import { Box, Button, Typography, useMediaQuery } from '@mui/material'
 import AppBar from '@mui/material/AppBar'
 import Container from '@mui/material/Container'
 import IconButton from '@mui/material/IconButton'
@@ -13,7 +13,7 @@ import Link from '@mui/material/Link'
 import MenuItem from '@mui/material/MenuItem'
 import Toolbar from '@mui/material/Toolbar'
 import { useRouter } from 'next/router'
-import * as React from 'react'
+import { useEffect, useState } from 'react'
 import { theme } from 'theme/theme'
 
 import OSLogo from '../assets/darkThemeLogo.svg'
@@ -41,7 +41,7 @@ const PATH_TO_SECTION = {
 
 const CommonHeader = () => {
   // React states and functions for handling the hamburger menu.
-  const [anchorElNav, setAnchorElNav] = React.useState<null | HTMLElement>(null)
+  const [anchorElNav, setAnchorElNav] = useState<null | HTMLElement>(null)
 
   const handleOpenNavMenu = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorElNav(event.currentTarget)
@@ -51,7 +51,8 @@ const CommonHeader = () => {
     setAnchorElNav(null)
   }
 
-  const [showMobileMenu, setShowMobileMenu] = React.useState(false);
+  const [showMobileMenu, setShowMobileMenu] = useState(false);
+  const smallScreen = useMediaQuery(theme.breakpoints.down('lg'))
 
   const router = useRouter()
 
@@ -157,6 +158,8 @@ const CommonHeader = () => {
           </Container>
         </Toolbar>
       </AppBar>
+      {/* the mobile slide-out menu */}
+      {smallScreen &&
       <Box sx={{ position: 'relative', zIndex: -1 }}>
         <MobileMenu yTranslate={showMobileMenu ? '0' : '-500px'}> 
             {Object.keys(SECTION_TO_PATH).map((name) => (
@@ -179,7 +182,7 @@ const CommonHeader = () => {
               </MenuItem>
             ))}
           </MobileMenu>
-      </Box>
+      </Box>}
     </Box>
   )
 }

--- a/components/MobileMenu.tsx
+++ b/components/MobileMenu.tsx
@@ -10,6 +10,7 @@ import {
   useMediaQuery,
   useTheme,
 } from '@mui/material'
+
 import { ReactNode } from 'react'
 
 type MobileMenuProps = {
@@ -17,11 +18,17 @@ type MobileMenuProps = {
 }
 
 const MobileMenu = ({ children }: MobileMenuProps) => {
+  const theme = useTheme()
+
   return (
   <Stack sx={{
-    backgroundColor: 'green',
-    height: '100vh',
-  }}>
+    position: 'absolute',
+    width: '100%',
+    alignItems: 'center',
+    gap: '1.5rem',
+    paddingY: '2.5rem',
+    backgroundColor: theme.palette.primary.main,
+}}>
     {children}
   </Stack>
 

--- a/components/MobileMenu.tsx
+++ b/components/MobileMenu.tsx
@@ -1,0 +1,31 @@
+/*
+ * Masthead.tsx
+ * @2023 Digital Aid Seattle
+ */
+
+import {
+  Stack,
+  Typography,
+  styled,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material'
+import { ReactNode } from 'react'
+
+type MobileMenuProps = {
+  children: ReactNode;
+}
+
+const MobileMenu = ({ children }: MobileMenuProps) => {
+  return (
+  <Stack sx={{
+    backgroundColor: 'green',
+    height: '100vh',
+  }}>
+    {children}
+  </Stack>
+
+  )
+}
+
+export default MobileMenu;

--- a/components/MobileMenu.tsx
+++ b/components/MobileMenu.tsx
@@ -5,9 +5,6 @@
 
 import {
   Stack,
-  Typography,
-  styled,
-  useMediaQuery,
   useTheme,
 } from '@mui/material'
 
@@ -15,9 +12,10 @@ import { ReactNode } from 'react'
 
 type MobileMenuProps = {
   children: ReactNode;
+  yTranslate: string;
 }
 
-const MobileMenu = ({ children }: MobileMenuProps) => {
+const MobileMenu = ({ children, yTranslate }: MobileMenuProps) => {
   const theme = useTheme()
 
   return (
@@ -28,6 +26,10 @@ const MobileMenu = ({ children }: MobileMenuProps) => {
     gap: '1.5rem',
     paddingY: '2.5rem',
     backgroundColor: theme.palette.primary.main,
+    borderBottom: `2px solid ${theme.palette.text.primary}`,
+    transform: `translateY(${yTranslate})`,
+    transition: 'all 0.4s ease-in-out',
+    zIndex: '-100'
 }}>
     {children}
   </Stack>

--- a/components/MobileMenu.tsx
+++ b/components/MobileMenu.tsx
@@ -7,7 +7,6 @@ import {
   Stack,
   useTheme,
 } from '@mui/material'
-
 import { ReactNode } from 'react'
 
 type MobileMenuProps = {
@@ -28,8 +27,7 @@ const MobileMenu = ({ children, yTranslate }: MobileMenuProps) => {
     backgroundColor: theme.palette.primary.main,
     borderBottom: `2px solid ${theme.palette.text.primary}`,
     transform: `translateY(${yTranslate})`,
-    transition: 'all 0.4s ease-in-out',
-    zIndex: '-100'
+    transition: 'all 0.66s ease',
 }}>
     {children}
   </Stack>


### PR DESCRIPTION
## What

> Summary of what you're changing.

- implement figma design of the mobile navigation.

## Why Do

> The motivation behind your change.

- mostly for fun. a nicer experience for phone users 

## How Do

> Implementation choices, reviewer notes, caveats, etc.

- created `MobileMenu` component, which takes in links in its `children` prop
- wrapped `CommonHeader` in a sticky-positioned `Box` to fix the issue with z-index and make the transition effect possible 

## Show Me

> Screenshot of your change, if applicable.
![image](https://github.com/openseattle/open-seattle-website/assets/60805050/45b3150c-1ad5-46fc-b863-1b3c8968b3fd)

