### PR TITLE
events page: section for past events

### DIFF
--- a/pages/events.tsx
+++ b/pages/events.tsx
@@ -99,14 +99,14 @@ const EventsPage = () => {
             )}
           </Stack>
         </SectionContainer>
-        <SectionContainer backgroundColor={theme.palette.background.default}>
+        {pastEvents.length > 0 && <SectionContainer backgroundColor={theme.palette.background.default}>
           <Stack gap={{ xs: '2.5rem', md: '2rem' }} maxWidth='880px'>
             <Typography variant="headlineLarge" sx={{ textAlign: 'center' }}>Past Events</Typography>
             {pastEvents.map((event) => (
               <CardEvent key={event.title} event={event} />
             ))}
           </Stack>
-        </SectionContainer>
+        </SectionContainer>}
       </BlockComponent>
     </>
   )

--- a/pages/events.tsx
+++ b/pages/events.tsx
@@ -10,11 +10,11 @@ import {
   useTheme
 } from '@mui/material'
 import CardEvent from 'components/cards/CardEvent'
+import SectionContainer from 'components/layout/SectionContainer'
 import { BlockComponent, LoadingContext, withBasicLayout } from 'components/layouts'
 import { useContext, useEffect, useState } from 'react'
-
-import SectionContainer from 'components/layout/SectionContainer'
 import { OSEvent } from 'types'
+
 import { eventsService } from './api/EventsService'
 
 type MastheadProps = {
@@ -70,33 +70,33 @@ const EventsPage = () => {
       })
   }, [setLoading])
 
+  let futureEvents = events.filter((event) => Date.parse(event.date) > Date.now());
+  let pastEvents = events.filter((event) => Date.parse(event.date) < Date.now());
+
   return (
     <>
       <Masthead title={title} />
       <BlockComponent block={!init}>
         <SectionContainer backgroundColor={theme.palette.background.default}>
-          <Box
-            sx={{
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-            }}
-            maxWidth={'880px'}
-          >
-            <Stack gap={{ xs: '2.5rem', md: '2rem' }} maxWidth={'880px'}>
-
-              {events.map((event) => (
+          <Stack alignItems='center' gap='4rem' maxWidth='880px'>
+            <Stack gap={{ xs: '2.5rem', md: '2rem' }} maxWidth='880px'>
+              {futureEvents.map((event) => (
                 <CardEvent key={event.title} event={event} />
               ))}
 
-              {events.length === 0 && (
+              {futureEvents.length === 0 && (
                 <Typography sx={{ textAlign: 'center' }}>
                   All upcoming events are invite-only. Please check back in the
                   future for public events.
                 </Typography>
               )}
             </Stack>
-          </Box>
+            <Stack gap={{ xs: '2.5rem', md: '2rem' }} maxWidth='880px'>
+              <Typography variant="headlineLarge" sx={{ textAlign: 'center' }}>Past Events</Typography>
+              {pastEvents.map((event) => (<CardEvent key={event.title} event={event} />
+              ))}
+            </Stack>
+          </Stack>
         </SectionContainer>
       </BlockComponent>
     </>

--- a/pages/events.tsx
+++ b/pages/events.tsx
@@ -70,8 +70,14 @@ const EventsPage = () => {
       })
   }, [setLoading])
 
-  let futureEvents = events.filter((event) => Date.parse(event.date) > Date.now());
-  let pastEvents = events.filter((event) => Date.parse(event.date) < Date.now());
+  const today = new Date();
+
+  let futureEvents = events.filter((event) => event.date >= today);
+  let pastEvents = events.filter((event) => event.date < today);
+  events.forEach((e) => {
+    console.log(e.date)
+    console.log('today', today)
+  })
 
   return (
     <>

--- a/pages/events.tsx
+++ b/pages/events.tsx
@@ -70,7 +70,8 @@ const EventsPage = () => {
       })
   }, [setLoading])
 
-  const today = new Date().toISOString().substring(0, 10);
+  //  gets today's date in the user's timezone, in ISO format (YYYY-MM-DD)
+  const today = new Date().toLocaleDateString("sv");
 
   let futureEvents = events.filter((event) => event.date >= today);
   let pastEvents = events.filter((event) => event.date < today);

--- a/pages/events.tsx
+++ b/pages/events.tsx
@@ -73,8 +73,9 @@ const EventsPage = () => {
   //  gets today's date in the user's timezone, in ISO format (YYYY-MM-DD)
   const today = new Date().toLocaleDateString("sv");
 
-  let futureEvents = events.filter((event) => event.date >= today);
-  let pastEvents = events.filter((event) => event.date < today);
+  const eventsDateDesc = events.sort((a, b) => Date.parse(b.date) - Date.parse(a.date));
+  let futureEvents = eventsDateDesc.filter((event) => event.date >= today);
+  let pastEvents = eventsDateDesc.filter((event) => event.date < today);
 
 
   events.forEach((e) => {

--- a/pages/events.tsx
+++ b/pages/events.tsx
@@ -3,7 +3,6 @@
  */
 
 import {
-  Box,
   Container,
   Stack,
   Typography,
@@ -55,27 +54,27 @@ const EventsPage = () => {
 
   const title = 'Events'
   const { setLoading } = useContext(LoadingContext);
-  const [events, setEvents] = useState<OSEvent[] | null>([])
+  const [futureEvents, setFutureEvents] = useState<OSEvent[] | null>([])
+  const [pastEvents, setPastEvents] = useState<OSEvent[] | null>([])
   const [init, setInit] = useState(false)
 
   useEffect(() => {
     setLoading(true);
     eventsService
       .getActiveEvents()
-      .then((evs) => setEvents(evs))
+      .then((evs) => {
+        //  gets today's date in the user's timezone, in ISO format (YYYY-MM-DD)
+        const today = new Date().toLocaleDateString("sv");
+        const eventsDescending = evs.sort((a, b) => Date.parse(b.date) - Date.parse(a.date));
+        setFutureEvents(eventsDescending.filter((event) => event.date >= today))
+        setPastEvents(eventsDescending.filter((event) => event.date < today))
+      })
       .catch((error) => console.log(error))
       .finally(() => {
         setLoading(false)
         setInit(true)
       })
   }, [setLoading])
-
-  //  gets today's date in the user's timezone, in ISO format (YYYY-MM-DD)
-  const today = new Date().toLocaleDateString("sv");
-
-  const eventsDateDesc = events.sort((a, b) => Date.parse(b.date) - Date.parse(a.date));
-  let futureEvents = eventsDateDesc.filter((event) => event.date >= today);
-  let pastEvents = eventsDateDesc.filter((event) => event.date < today);
 
   return (
     <>

--- a/pages/events.tsx
+++ b/pages/events.tsx
@@ -77,12 +77,6 @@ const EventsPage = () => {
   let futureEvents = eventsDateDesc.filter((event) => event.date >= today);
   let pastEvents = eventsDateDesc.filter((event) => event.date < today);
 
-
-  events.forEach((e) => {
-    console.log(e.title, e.date)
-    console.log('today', today)
-  })
-
   return (
     <>
       <Masthead title={title} />

--- a/pages/events.tsx
+++ b/pages/events.tsx
@@ -70,12 +70,14 @@ const EventsPage = () => {
       })
   }, [setLoading])
 
-  const today = new Date();
+  const today = new Date().toISOString().substring(0, 10);
 
   let futureEvents = events.filter((event) => event.date >= today);
   let pastEvents = events.filter((event) => event.date < today);
+
+
   events.forEach((e) => {
-    console.log(e.date)
+    console.log(e.title, e.date)
     console.log('today', today)
   })
 

--- a/pages/events.tsx
+++ b/pages/events.tsx
@@ -78,24 +78,24 @@ const EventsPage = () => {
       <Masthead title={title} />
       <BlockComponent block={!init}>
         <SectionContainer backgroundColor={theme.palette.background.default}>
-          <Stack alignItems='center' gap='4rem' maxWidth='880px'>
-            <Stack gap={{ xs: '2.5rem', md: '2rem' }} maxWidth='880px'>
-              {futureEvents.map((event) => (
-                <CardEvent key={event.title} event={event} />
-              ))}
-
-              {futureEvents.length === 0 && (
-                <Typography sx={{ textAlign: 'center' }}>
-                  All upcoming events are invite-only. Please check back in the
-                  future for public events.
-                </Typography>
-              )}
-            </Stack>
-            <Stack gap={{ xs: '2.5rem', md: '2rem' }} maxWidth='880px'>
-              <Typography variant="headlineLarge" sx={{ textAlign: 'center' }}>Past Events</Typography>
-              {pastEvents.map((event) => (<CardEvent key={event.title} event={event} />
-              ))}
-            </Stack>
+          <Stack gap={{ xs: '2.5rem', md: '2rem' }} maxWidth='880px'>
+            {futureEvents.map((event) => (
+              <CardEvent key={event.title} event={event} />
+            ))}
+            {futureEvents.length === 0 && (
+              <Typography sx={{ textAlign: 'center' }}>
+                All upcoming events are invite-only. Please check back in the
+                future for public events.
+              </Typography>
+            )}
+          </Stack>
+        </SectionContainer>
+        <SectionContainer backgroundColor={theme.palette.background.default}>
+          <Stack gap={{ xs: '2.5rem', md: '2rem' }} maxWidth='880px'>
+            <Typography variant="headlineLarge" sx={{ textAlign: 'center' }}>Past Events</Typography>
+            {pastEvents.map((event) => (
+              <CardEvent key={event.title} event={event} />
+            ))}
           </Stack>
         </SectionContainer>
       </BlockComponent>

--- a/sanity/schemas/osEvent.ts
+++ b/sanity/schemas/osEvent.ts
@@ -14,7 +14,7 @@ export default {
         },
         {
             name: 'date',
-            type: 'string',
+            type: 'date',
             title: 'Date'
         },
         {

--- a/types.d.ts
+++ b/types.d.ts
@@ -7,7 +7,7 @@ type OSEvent = {
   _id: string,
   _createdAt: Date,
   title: string,
-  date: string,
+  date: Date,
   start: string,
   end: string,
   location: string,

--- a/types.d.ts
+++ b/types.d.ts
@@ -7,7 +7,7 @@ type OSEvent = {
   _id: string,
   _createdAt: Date,
   title: string,
-  date: Date,
+  date: string,
   start: string,
   end: string,
   location: string,


### PR DESCRIPTION
## What

> Summary of what you're changing.

upcoming events and past events are rendered in separate sections.
just did some simple array filtering on the airtable data!

## Why Do

> The motivation behind your change.

per design spec; to separate upcoming and past events.

## Show Me

> Screenshot of your change, if applicable.

how it looks without upcoming events (like current website):

![image](https://github.com/openseattle/open-seattle-website/assets/60805050/130d9625-8722-4790-adf0-75fa8b09ef80)

mocking multiple events
![image](https://github.com/openseattle/open-seattle-website/assets/60805050/d1e74489-df68-4f51-9490-a666fe5c4e16)


