### PR TITLE
cap description length to 4 lines

### DIFF
--- a/components/cards/CardProject.tsx
+++ b/components/cards/CardProject.tsx
@@ -83,7 +83,15 @@ const CardProject = ({ project }: CardProjectProps) => {
               </Stack>
             </Stack>
           </Stack>
-          <Typography variant="bodyMedium">{project.description}</Typography>
+          <Typography
+            sx={{
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              display: "-webkit-box",
+              WebkitLineClamp: "5",
+              WebkitBoxOrient: "vertical"
+            }}
+            variant="bodyMedium" >{project.description}</Typography>
         </CardContent>
       </CardActionArea>
     </Card>

--- a/components/cards/CardProject.tsx
+++ b/components/cards/CardProject.tsx
@@ -88,7 +88,7 @@ const CardProject = ({ project }: CardProjectProps) => {
               overflow: "hidden",
               textOverflow: "ellipsis",
               display: "-webkit-box",
-              WebkitLineClamp: "5",
+              WebkitLineClamp: "4",
               WebkitBoxOrient: "vertical"
             }}
             variant="bodyMedium" >{project.description}</Typography>


### PR DESCRIPTION
## What

> Capping the length  of description to 4 lines

## Why Do

> limit length of card to fit more cards on a page

## Show Me


![Screen Shot 2024-04-11 at 09 46 36](https://github.com/openseattle/open-seattle-website/assets/11780107/56446daf-4200-4f18-bf72-225ff68934f3)

