### PR TITLE
fit partner image to fit in card

### DIFF
--- a/components/cards/CardProject.tsx
+++ b/components/cards/CardProject.tsx
@@ -47,9 +47,9 @@ const CardProject = ({ project }: CardProjectProps) => {
               component="img"
               image={project.imageSrc ? project.imageSrc : urlForImage(project.image).url()}
               sx={{
+                objectFit: "contain",
                 width: { md: '7rem', lg: '100%' },
                 aspectRatio: '1 / 1',
-                border: '2px solid #EAF1F1',
                 borderRadius: '8px',
                 display: { xs: 'none', md: 'block' },
               }}


### PR DESCRIPTION
## What

> Project card log image fix
> Removed border around image

## Why Do

> Partner logos come in many sizes.  Doing our best to make them fit

## How Do

> Implementation choices, reviewer notes, caveats, etc.

## Show Me

<img width="565" alt="Screenshot 2024-04-22 at 1 11 44 PM" src="https://github.com/openseattle/open-seattle-website/assets/11780107/483c5d97-33b9-4ad4-8d33-59e0c67d5830">
<img width="445" alt="Screenshot 2024-04-22 at 1 13 04 PM" src="https://github.com/openseattle/open-seattle-website/assets/11780107/c773049f-434c-469c-a06c-b317d1c65a96">

