### PR TITLE
Dw 141 add links to HR policies

### DIFF
--- a/components/RolesSection.tsx
+++ b/components/RolesSection.tsx
@@ -171,7 +171,7 @@ const FilterableRoles = ({ roles, showLink }) => {
   useEffect(() => {
     setRolesToDisplay([...roles]);
     // using a set to build a list of categories that occur in roles data
-    const uniqueCategories = new Set()
+    const uniqueCategories = new Set();
     roles.forEach(r => r.category && r.category.forEach(c => uniqueCategories.add(c)))
     setCategories(Array.from(uniqueCategories))
   }, [roles]);

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "singleQuote": true
   },
   "dependencies": {
+    "@digitalaidseattle/core": "^1.0.16",
     "@emotion/react": "^11.13.0",
     "@emotion/styled": "^11.13.0",
     "@mui/icons-material": "^6.1.3",

--- a/pages/cadre.tsx
+++ b/pages/cadre.tsx
@@ -19,11 +19,12 @@ import {
   ProjectTeamSection
 } from 'components/ProjectComponents'
 import RolesSection from 'components/RolesSection'
+import { CodaVolunteerService } from 'services/codaVolunteerService'
 import { pageCopyService } from 'services/PageCopyService'
 import { DASProject, DASVolunteerRoleBasicInfo, TeamMember } from 'types'
 import ProjectImage from '../assets/project-image.png'
-import { dasProjectsService } from '../services/ProjectsService'
 import { dasVolunteerRoleService } from '../services/VolunteerRoleService'
+import { CodaRoleService } from 'services/codaRoleService'
 
 const LABELS = {
   HERO_LBL: 'The Cadre',
@@ -47,6 +48,9 @@ const TheCadrePage = () => {
 
   const [initialized, setInitialized] = useState<boolean>(false);
 
+  const volunteerService = CodaVolunteerService.getInstance();
+  const roleService = CodaRoleService.getInstance();
+
   useEffect(() => {
     if (!initialized) {
       pageCopyService
@@ -64,15 +68,23 @@ const TheCadrePage = () => {
   useEffect(() => {
     setLoading(true);
     Promise.all([
-      dasVolunteerRoleService.getAllActiveRoles(),
-      dasProjectsService.getPeople('Cadre')
+      roleService.getAllActiveRoles(),
+      volunteerService.getPeople('Cadre')
     ])
       .then(resps => {
+        console.log('TheCadrePage', resps);
         setVolunteerRoles(resps[0]);
         setMembers(resps[1].sort((r1, r2) => r1.name.localeCompare(r2.name)));
       })
       .catch((error) => console.error(error))
-      .finally(() => setLoading(false))
+      .finally(() => setLoading(false));
+
+    roleService.findBy('key', 'chief-of-staff')
+      .then(roles => {
+        console.log('Roles found by key', roles);
+      })
+      .catch((error) => console.error(error))
+      .finally(() => setLoading(false));
   }, [setLoading])
 
   const theme = useTheme()

--- a/pages/cadre.tsx
+++ b/pages/cadre.tsx
@@ -19,12 +19,11 @@ import {
   ProjectTeamSection
 } from 'components/ProjectComponents'
 import RolesSection from 'components/RolesSection'
+import { CodaRoleService } from 'services/codaRoleService'
 import { CodaVolunteerService } from 'services/codaVolunteerService'
 import { pageCopyService } from 'services/PageCopyService'
 import { DASProject, DASVolunteerRoleBasicInfo, TeamMember } from 'types'
 import ProjectImage from '../assets/project-image.png'
-import { dasVolunteerRoleService } from '../services/VolunteerRoleService'
-import { CodaRoleService } from 'services/codaRoleService'
 
 const LABELS = {
   HERO_LBL: 'The Cadre',
@@ -48,9 +47,6 @@ const TheCadrePage = () => {
 
   const [initialized, setInitialized] = useState<boolean>(false);
 
-  const volunteerService = CodaVolunteerService.getInstance();
-  const roleService = CodaRoleService.getInstance();
-
   useEffect(() => {
     if (!initialized) {
       pageCopyService
@@ -68,20 +64,13 @@ const TheCadrePage = () => {
   useEffect(() => {
     setLoading(true);
     Promise.all([
-      roleService.getAllActiveRoles(),
-      volunteerService.getPeople('Cadre')
+      CodaRoleService.getInstance().getAllActiveRoles(),
+      CodaVolunteerService.getInstance().getPeople('Cadre')
     ])
       .then(resps => {
         console.log('TheCadrePage', resps);
         setVolunteerRoles(resps[0]);
         setMembers(resps[1].sort((r1, r2) => r1.name.localeCompare(r2.name)));
-      })
-      .catch((error) => console.error(error))
-      .finally(() => setLoading(false));
-
-    roleService.findBy('key', 'chief-of-staff')
-      .then(roles => {
-        console.log('Roles found by key', roles);
       })
       .catch((error) => console.error(error))
       .finally(() => setLoading(false));

--- a/pages/projects.tsx
+++ b/pages/projects.tsx
@@ -26,6 +26,7 @@ import { dasProjectsService } from '../services/ProjectsService'
 import MastheadWithImage from 'components/MastheadWithImage'
 import ProjectsImage from '../assets/projects.png'
 import { pageCopyService } from 'services/PageCopyService'
+import { CodaVentureService } from 'services/codaVentureService'
 
 const LABELS = {
   HERO_TITLE: 'Projects',
@@ -44,6 +45,17 @@ const ProjectsPage = () => {
   const [projects, setProjects] = useState<DASProject[]>([]);
   const [filterStatuses, setFilterStatuses] = useState<string[]>([]);
   const [displayedProjects, setDisplayedProjects] = useState<DASProject[]>([]);
+
+
+  const codaVentureService = CodaVentureService.getInstance();
+  useEffect(() => {
+    codaVentureService
+      .getAll()
+      .then(ventures => {
+        console.log('Coda ventures:', ventures);
+      })
+      .catch(error => console.error('Error fetching Coda ventures:', error));
+  }, [codaVentureService])
 
   useEffect(() => {
     if (!init) {

--- a/pages/projects.tsx
+++ b/pages/projects.tsx
@@ -49,38 +49,25 @@ const ProjectsPage = () => {
   const [filterStatuses, setFilterStatuses] = useState<string[]>([]);
   const [displayedProjects, setDisplayedProjects] = useState<DASProject[]>([]);
 
+  const ventureService = CodaVentureService.getInstance();
+  const partnerService = CodaPartnerService.getInstance();
 
-  const codaVentureService = CodaVentureService.getInstance();
   useEffect(() => {
-    codaVentureService
+    ventureService
       .getAll()
       .then(ventures => {
         console.log('Coda ventures:', ventures);
       })
       .catch(error => console.error('Error fetching Coda ventures:', error));
 
-    CodaVolunteerService.getInstance()
-      .getAll()
-      .then(entities => {
-        console.log('Coda volunteers:', entities);
-      })
-      .catch(error => console.error('Error fetching Coda volunteers:', error));
-
-    CodaPartnerService.getInstance()
+    partnerService
       .getAll()
       .then(entities => {
         console.log('Coda partners:', entities);
       })
       .catch(error => console.error('Error fetching Coda partners:', error));
 
-    CodaRoleService.getInstance()
-      .getAll()
-      .then(entities => {
-        console.log('Coda roles:', entities);
-      })
-      .catch(error => console.error('Error fetching Coda roles:', error));
-
-  }, [codaVentureService])
+  }, [ventureService, partnerService]);
 
   useEffect(() => {
     if (!init) {

--- a/pages/projects.tsx
+++ b/pages/projects.tsx
@@ -27,6 +27,9 @@ import MastheadWithImage from 'components/MastheadWithImage'
 import ProjectsImage from '../assets/projects.png'
 import { pageCopyService } from 'services/PageCopyService'
 import { CodaVentureService } from 'services/codaVentureService'
+import { CodaVolunteerService } from 'services/codaVolunteerService'
+import { CodaPartnerService } from 'services/codaPartnerService'
+import { CodaRoleService } from 'services/codaRoleService'
 
 const LABELS = {
   HERO_TITLE: 'Projects',
@@ -55,6 +58,28 @@ const ProjectsPage = () => {
         console.log('Coda ventures:', ventures);
       })
       .catch(error => console.error('Error fetching Coda ventures:', error));
+
+    CodaVolunteerService.getInstance()
+      .getAll()
+      .then(entities => {
+        console.log('Coda volunteers:', entities);
+      })
+      .catch(error => console.error('Error fetching Coda volunteers:', error));
+
+    CodaPartnerService.getInstance()
+      .getAll()
+      .then(entities => {
+        console.log('Coda partners:', entities);
+      })
+      .catch(error => console.error('Error fetching Coda partners:', error));
+
+    CodaRoleService.getInstance()
+      .getAll()
+      .then(entities => {
+        console.log('Coda roles:', entities);
+      })
+      .catch(error => console.error('Error fetching Coda roles:', error));
+
   }, [codaVentureService])
 
   useEffect(() => {

--- a/pages/volunteer/[...slug].tsx
+++ b/pages/volunteer/[...slug].tsx
@@ -17,6 +17,7 @@ import { DASVolunteerRole } from 'types'
 import { dasVolunteerRoleService, VOLUNTEER_APPLICATION_FORM_URL } from '../../services/VolunteerRoleService'
 import Markdown from 'react-markdown'
 import { useRouter } from 'next/router'
+import { CodaRoleService } from 'services/codaRoleService'
 
 const Labels = {
   Title: "Volunteer Opening",
@@ -46,7 +47,8 @@ const VolunteerRolePage = () => {
     setLoading(true);
     const roleName = router.query.slug ? router.query.slug[0] : null;
     if (roleName) {
-      dasVolunteerRoleService
+      // dasVolunteerRoleService
+      CodaRoleService.getInstance()
         .getRoleDetailsByName(roleName)
         .then((resp: DASVolunteerRole) => {
           if (resp === null) {

--- a/pages/volunteers.tsx
+++ b/pages/volunteers.tsx
@@ -36,6 +36,7 @@ import { DASVolunteerRoleBasicInfo } from 'types'
 import { pageCopyService } from 'services/PageCopyService'
 import VolunteerImage from '../assets/volunteerWithUs.png'
 import { dasVolunteerRoleService, VOLUNTEER_APPLICATION_FORM_URL } from '../services/VolunteerRoleService'
+import { CodaRoleService } from 'services/codaRoleService'
 
 /* eslint-disable @next/next/no-img-element */
 
@@ -101,12 +102,14 @@ const VolunteerPage = () => {
   const { setLoading } = useContext(LoadingContext);
   const [initialized, setInitialized] = useState<boolean>(false);
 
+  const roleService = CodaRoleService.getInstance();
+
   useEffect(() => {
     if (!initialized) {
       setLoading(true);
 
       Promise.all([
-        dasVolunteerRoleService.getAllActiveRoles(),
+        roleService.getAllActiveRoles(),
 
         pageCopyService
           .updateCopy(LABELS, 'volunteers')

--- a/pages/volunteers.tsx
+++ b/pages/volunteers.tsx
@@ -34,9 +34,9 @@ import { designColor } from 'theme/theme'
 import { DASVolunteerRoleBasicInfo } from 'types'
 
 import { pageCopyService } from 'services/PageCopyService'
-import VolunteerImage from '../assets/volunteerWithUs.png'
-import { dasVolunteerRoleService, VOLUNTEER_APPLICATION_FORM_URL } from '../services/VolunteerRoleService'
 import { CodaRoleService } from 'services/codaRoleService'
+import VolunteerImage from '../assets/volunteerWithUs.png'
+import { VOLUNTEER_APPLICATION_FORM_URL } from '../services/VolunteerRoleService'
 
 /* eslint-disable @next/next/no-img-element */
 
@@ -102,15 +102,12 @@ const VolunteerPage = () => {
   const { setLoading } = useContext(LoadingContext);
   const [initialized, setInitialized] = useState<boolean>(false);
 
-  const roleService = CodaRoleService.getInstance();
-
   useEffect(() => {
     if (!initialized) {
       setLoading(true);
 
       Promise.all([
-        roleService.getAllActiveRoles(),
-
+        CodaRoleService.getInstance().getAllActiveRoles(),
         pageCopyService
           .updateCopy(LABELS, 'volunteers')
       ])

--- a/pages/volunteers.tsx
+++ b/pages/volunteers.tsx
@@ -32,6 +32,7 @@ import Link from 'next/link'
 import React, { useContext, useEffect, useState } from 'react'
 import { designColor } from 'theme/theme'
 import { DASVolunteerRoleBasicInfo } from 'types'
+import Markdown from 'react-markdown'
 
 import { pageCopyService } from 'services/PageCopyService'
 import { CodaRoleService } from 'services/codaRoleService'
@@ -283,7 +284,7 @@ const VolunteerPage = () => {
                     color={palette.primary.main}
                   >{`${index + 1}.`}</Typography>
                   <Typography variant="bodyLarge" mx={2}>
-                    {item}
+                    <Markdown className='markdown'>{item}</Markdown>
                   </Typography>
                 </li>
               ))}

--- a/services/codaPartnerService.ts
+++ b/services/codaPartnerService.ts
@@ -1,0 +1,46 @@
+/**
+ *  codaPartnerService.ts
+ *
+ *  @copyright 2024 Digital Aid Seattle
+ *
+ */
+
+import { Entity } from '@digitalaidseattle/core';
+import { CodaRow, CodaService } from './codaService';
+
+type Partner = Entity & {
+    _createdAt: Date,
+    name: string,
+    role: string,
+    url: string
+}
+
+const CODA_DOC_ID = "r6VtSC7MPA";
+const TABLE_ID = 'grid-qFnhGRfW7C';
+
+function coda2Entity(row: CodaRow): Partner {
+    console.log('Partner', row)
+
+    const entity = {
+
+    } as Partner;
+    return entity;
+}
+
+class CodaPartnerService extends CodaService<Partner> {
+
+    static instance: CodaPartnerService;
+    static getInstance(): CodaPartnerService {
+        if (!CodaPartnerService.instance) {
+            CodaPartnerService.instance = new CodaPartnerService();
+        }
+        return CodaPartnerService.instance;
+    }
+
+    constructor() {
+        super(CODA_DOC_ID, TABLE_ID, undefined, coda2Entity, undefined);
+    }
+}
+
+export { CodaPartnerService };
+

--- a/services/codaRoleService.ts
+++ b/services/codaRoleService.ts
@@ -17,6 +17,7 @@ const TABLE_ID = 'grid-YIZ0HWUd3o';
 
 function coda2Entity(row: CodaRow): Role {
     const entity = {
+        id: row.id,
         key: row.values['Key'] ? row.values['Key'].replaceAll('```', '') : '',
         role: row.values['Role'] ? row.values['Role'].replaceAll('```', '') : '',
         url: row.values['Pic'] ? row.values['Pic'][0].url : '',

--- a/services/codaRoleService.ts
+++ b/services/codaRoleService.ts
@@ -1,0 +1,73 @@
+/**
+ *  codaRoleService.ts
+ *
+ *  @copyright 2024 Digital Aid Seattle
+ *
+ */
+
+import { DASVolunteerRole, DASVolunteerRoleBasicInfo } from 'types';
+import { CodaRow, CodaService } from './codaService';
+
+type Role = DASVolunteerRole & {
+    status: string;
+}
+
+const CODA_DOC_ID = "24QYb2RP0g";
+const TABLE_ID = 'grid-YIZ0HWUd3o';
+
+function coda2Entity(row: CodaRow): Role {
+    const entity = {
+        key: row.values['Key'] ? row.values['Key'].replaceAll('```', '') : '',
+        role: row.values['Role'] ? row.values['Role'].replaceAll('```', '') : '',
+        url: row.values['Pic'] ? row.values['Pic'][0].url : '',
+        keyTechnologies: row.values['Category'] ? row.values['Category'].map((s: any) => s.name) : [],
+        category: row.values['Category'] ? row.values['Category'].map((s: any) => s.name) : [],
+        status: row.values['Status'] ? row.values['Status'].replaceAll('```', '') : '',
+        location: row.values['Location'] ? row.values['Location'].replaceAll('```', '') : '',
+        duration: row.values['Duration'] ? row.values['Duration'].replaceAll('```', '') : '',
+        headline: row.values['Headline'] ? row.values['Headline'].replaceAll('```', '') : '',
+        description: row.values['Description'] ? row.values['Description'].replaceAll('```', '') : '',
+        aboutUs: row.values['About Us'] ? row.values['About Us'].replaceAll('```', '') : '',
+        responsibilities: row.values['Responsibilities'] ? row.values['Responsibilities'].replaceAll('```', '') : '',
+        preferredQualifications: row.values['Preferred Qualifications'] ? row.values['Preferred Qualifications'].replaceAll('```', '') : '',
+        keyAttributesToSuccess: row.values['Key attributes for success'] ? row.values['Key attributes for success'].replaceAll('```', '') : '',
+        whyJoin: row.values['Why Join'] ? row.values['Why Join'].replaceAll('```', '') : '',
+    } as Role;
+    return entity;
+}
+
+class CodaRoleService extends CodaService<Role> {
+
+    static instance: CodaRoleService;
+    static getInstance(): CodaRoleService {
+        if (!CodaRoleService.instance) {
+            CodaRoleService.instance = new CodaRoleService();
+        }
+        return CodaRoleService.instance;
+    }
+
+    constructor() {
+        super(CODA_DOC_ID, TABLE_ID, undefined, coda2Entity, undefined);
+    }
+
+    getAllActiveRoles(): Promise<DASVolunteerRoleBasicInfo[]> {
+        return this.getAll()
+            .then(roles => roles.filter(r => r.status === 'Active')
+                .map(r => {
+                    return {
+                        role: r.role,
+                        key: r.key,
+                        category: r.category
+                    } as DASVolunteerRoleBasicInfo;
+                })
+            );
+    }
+
+    getRoleDetailsByName(key: string): Promise<DASVolunteerRole | null> {
+        return this.findBy('Key', key)
+            .then(roles => roles.length > 0 ? roles[0] : null)
+    }
+
+}
+
+export { CodaRoleService };

--- a/services/codaService.ts
+++ b/services/codaService.ts
@@ -1,0 +1,113 @@
+/**
+ *  codaService.ts
+ *
+ *  @copyright 2024 Digital Aid Seattle
+ *
+ */
+
+import { Entity, EntityService, Identifier, User } from "@digitalaidseattle/core";
+
+const CODA_API_TOKEN = process.env.NEXT_PUBLIC_CODA_API_TOKEN;
+const CODA_DOC_ID = "24QYb2RP0g";
+const CODA_API_BASE = `https://coda.io/apis/v1/docs/${CODA_DOC_ID}`;
+
+type CodaRow = {
+    id: string;
+    values: Record<string, any>;
+}
+
+abstract class CodaService<T extends Entity> implements EntityService<T> {
+    tableName = '';
+    select = '*';
+    mapper = (json: any) => (json as T);
+    entityToCodaMapper = (_entity: T) => ({} as any);
+
+    constructor(tableName: string, select?: string, mapper?: (json: any) => T, entityToCodaMapper?: (_entity: T) => {}) {
+        this.tableName = tableName;
+        this.select = select ?? '*';
+        this.mapper = mapper ?? ((json: any) => json);
+        this.entityToCodaMapper = entityToCodaMapper ?? ((_entity: any) => ({} as any));
+    }
+
+    getById(_id: Identifier, _select?: string, _mapper?: ((json: any) => T) | undefined): Promise<T | null> {
+        throw new Error("Method not implemented.");
+    }
+
+    insert(_entity: T, _select?: string, _mapper?: ((json: any) => T) | undefined, _user?: User): Promise<T> {
+        throw new Error("Method not implemented.");
+    }
+
+    update(_id: Identifier, _changes: Partial<T>, _select?: string, _mapper?: ((json: any) => T) | undefined, _user?: User): Promise<T> {
+        throw new Error("Method not implemented.");
+    }
+
+    delete(_id: Identifier, _user?: User): Promise<void> {
+        throw new Error("Method not implemented.");
+    }
+
+    async getAll(_count?: number, _select?: string, _mapper?: (json: any) => T): Promise<T[]> {
+        const url = `${CODA_API_BASE}/tables/${this.tableName}/rows?useColumnNames=true&valueFormat=rich`;
+        const resp = await fetch(url, {
+            headers: { 'Authorization': `Bearer ${CODA_API_TOKEN}` }
+        });
+
+        if (!resp.ok) {
+            const error = await resp.json().catch(() => ({ message: resp.statusText }));
+            throw new Error(`Failed to fetch rows: ${error.message || resp.statusText}`);
+        }
+
+        const data = await resp.json();
+        return data.items.map((json: any) => this.mapper(json))
+    }
+
+    async batchInsert(entities: T[], _select?: string, _mapper?: (json: any) => T, _user?: User): Promise<T[]> {
+        // }
+        // async createRows(tableId: string, rows: { cells: { column: string, value: any }[] }[]): Promise<any> {
+        const rows = entities.map(entity => this.entityToCodaMapper(entity));
+
+        const resp = await fetch(`${CODA_API_BASE}/tables/${this.tableName}/rows`, {
+            method: 'POST',
+            headers: {
+                'Authorization': `Bearer ${CODA_API_TOKEN}`,
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ rows })
+        });
+
+        // Coda API returns 202 Accepted for async processing
+        if (resp.status !== 202 && !resp.ok) {
+            const error = await resp.json()
+                .catch(() => ({ message: resp.statusText }));
+            throw new Error(`Failed to create rows: ${error.message || resp.statusText}`);
+        }
+
+        // Return the response (202 Accepted means the request was queued successfully)
+        return resp.json()
+            .then(data => {
+                console.log(data)
+                // TODO look up rows
+                return data.addedRowIds.map((id: string) => ({ id: id }))
+            })
+
+    }
+
+    async findBy(column: string, name: string): Promise<T[]> {
+        const url = `${CODA_API_BASE}/tables/${this.tableName}/rows?query=${column}:"${name}"`;
+        console.log(url)
+        const resp = await fetch(encodeURI(url), {
+            headers: { 'Authorization': `Bearer ${CODA_API_TOKEN}` }
+        });
+
+        if (!resp.ok) {
+            const error = await resp.json().catch(() => ({ message: resp.statusText }));
+            throw new Error(`Failed to fetch rows: ${error.message || resp.statusText}`);
+        }
+
+        const data = await resp.json();
+        return data.items.map((json: any) => this.mapper(json))
+    }
+}
+
+export { CodaService };
+export type { CodaRow }
+

--- a/services/codaService.ts
+++ b/services/codaService.ts
@@ -30,20 +30,156 @@ abstract class CodaService<T extends Entity> implements EntityService<T> {
         this.entityToCodaMapper = entityToCodaMapper ?? ((_entity: any) => ({} as any));
     }
 
-    getById(_id: Identifier, _select?: string, _mapper?: ((json: any) => T) | undefined): Promise<T | null> {
-        throw new Error("Method not implemented.");
+    /* 
+     * Get a single row by ID
+     * Copying the pattern from AirtableService.ts and adapting to Coda API
+     * using getall as a reference
+     * @returns the row or null if not found
+     * @ param _id the ID of the row to get
+     * @ param _select optional select string to override default (ignored)
+     * @ param _mapper optional mapper function to override default
+    */
+    async getById(_id: Identifier, _select?: string, _mapper?: ((json: any) => T) | undefined): Promise<T | null> {
+        if (!_id) return null;
+
+        // Prepare query parameters
+        const params = new URLSearchParams({
+            // Coda uses useColumnNames to return column names instead of IDs
+            useColumnNames: "true",
+            // valueFormat rich returns formatted values
+            valueFormat: "rich"
+        });
+
+        // This gets ignored but good for backwards compatibility
+        const select = _select ?? this.select;
+        if (select) {
+            params.set('select', select);
+        }
+
+        // Fetch the row from Coda API
+        const url = `${CODA_API_BASE}/${this.documentId}/tables/${this.tableName}/rows/${_id}?${params.toString()}`;
+        const resp = await fetch(encodeURI(url), {
+            headers: { Authorization: `Bearer ${CODA_API_TOKEN}` },
+        });
+
+        // Check for not found
+        if (resp.status === 404) return null;
+        if (!resp.ok) {
+            const error = await resp.json().catch(() => ({ message: resp.statusText }));
+            throw new Error(`Failed to fetch row: ${error.message || resp.statusText}`);
+        }
+
+        // Parse and map the result
+        const data = await resp.json();
+        const mapper = _mapper ?? this.mapper;
+        return mapper(data);
     }
 
-    insert(_entity: T, _select?: string, _mapper?: ((json: any) => T) | undefined, _user?: User): Promise<T> {
-        throw new Error("Method not implemented.");
+    /*
+     * Insert a single row into the configured Coda table.
+     * @param _entity The entity object to insert (mapped to Coda row format).
+     * @param _select Optional select string to influence returned fields (passed through to `getById`).
+     * @param _mapper Optional mapper function to transform the returned JSON into a T.
+     * @param _user Optional user performing the insert (currently unused).
+     * @returns The newly created entity (mapped via `_mapper` or the service mapper) or `null` if the create did not return an ID.
+     * @throws On non-202/non-ok responses with a message from the Coda API.
+     */
+    async insert(_entity: T, _select?: string, _mapper?: ((json: any) => T) | undefined, _user?: User): Promise<T | null> {
+        // get rows to insert
+        const rows = [this.entityToCodaMapper(_entity)];
+        
+        // make the request to Coda API
+        const resp = await fetch(`${CODA_API_BASE}/${this.documentId}/tables/${this.tableName}/rows`, {
+            method: 'POST',
+            headers: {
+                'Authorization': `Bearer ${CODA_API_TOKEN}`,
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ rows })
+        });
+
+        // Coda API returns 202 Accepted for async processing
+        if (resp.status !== 202 && !resp.ok) {
+            const error = await resp.json()
+                .catch(() => ({ message: resp.statusText }));
+            throw new Error(`Failed to create row: ${error.message || resp.statusText}`);
+        }
+
+        // Parse the response to get the added row ID
+        const data = await resp.json();
+        const addedId = data.addedRowIds?.[0];
+        
+        // If no ID returned, return null
+        if (!addedId) return null;
+        
+        // Fetch and return the newly created row using our new getById method!
+        return this.getById(addedId, _select, _mapper);
     }
 
-    update(_id: Identifier, _changes: Partial<T>, _select?: string, _mapper?: ((json: any) => T) | undefined, _user?: User): Promise<T> {
-        throw new Error("Method not implemented.");
+
+    /*
+     * Update an existing row by ID.
+     * @param _id The ID of the row to update.
+     * @param _changes Partial entity with updates to apply.
+     * @param _select Optional select string to pass to `getById` when returning the updated row.
+     * @param _mapper Optional mapper to override the default mapper used for the returned row.
+     * @param _user Optional user performing the update (currently unused).
+     * @returns The updated entity or `null` if not found.
+     * @throws On non-ok non-404 responses containing the Coda API error message.
+     */
+    async update(_id: Identifier, _changes: Partial<T>, _select?: string, _mapper?: ((json: any) => T) | undefined, _user?: User): Promise<T | null> {
+        if (!_id) return null;
+
+        // Map the incoming changes to the Coda row format using the entity mapper.
+        const row = this.entityToCodaMapper(_changes as T);
+
+        const resp = await fetch(`${CODA_API_BASE}/${this.documentId}/tables/${this.tableName}/rows/${_id}`, {
+            method: 'PUT',
+            headers: {
+                'Authorization': `Bearer ${CODA_API_TOKEN}`,
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ row })
+        });
+
+        // Not found
+        if (resp.status === 404) return null;
+
+        if (!resp.ok) {
+            const error = await resp.json().catch(() => ({ message: resp.statusText }));
+            throw new Error(`Failed to update row: ${error.message || resp.statusText}`);
+        }
+
+        // Fetch and return the updated row using our existing getById for consistency
+        return this.getById(_id, _select, _mapper);
     }
 
-    delete(_id: Identifier, _user?: User): Promise<void> {
-        throw new Error("Method not implemented.");
+    /*
+    * Delete a row by ID.
+    * @param _id The ID of the row to delete.
+    * @param _user Optional user performing the deletion (currently unused).
+    * @returns Promise that resolves when deletion is complete.
+    * @throws On non-ok non-404 responses containing the Coda API error message.
+    */
+    async delete(_id: Identifier, _user?: User): Promise<void> {
+        if (!_id) return;
+
+        const resp = await fetch(`${CODA_API_BASE}/${this.documentId}/tables/${this.tableName}/rows/${_id}`, {
+            method: 'DELETE',
+            headers: {
+                'Authorization': `Bearer ${CODA_API_TOKEN}`,
+            },
+        });
+
+        // If the row wasn't found, treat as no-op
+        if (resp.status === 404) return;
+
+        if (!resp.ok) {
+            const error = await resp.json().catch(() => ({ message: resp.statusText }));
+            throw new Error(`Failed to delete row: ${error.message || resp.statusText}`);
+        }
+
+        return;
     }
 
     async getAll(_count?: number, _select?: string, _mapper?: (json: any) => T): Promise<T[]> {

--- a/services/codaVentureService.ts
+++ b/services/codaVentureService.ts
@@ -32,11 +32,12 @@ type Venture = {
     imageSrc: string,
     ventureCode: string
 }
-// @ts-ignore - Environment variables are defined at runtime
+
+const CODA_DOC_ID = "24QYb2RP0g";
 const VENTURE_TABLE_ID = 'grid-UdXLv7wwqh';
 
 function coda2Entity(row: CodaRow): Venture {
-    console.log(row)
+    console.log('Venture', row)
 
     const venture = {
         title: row.values['c-VmSQh523FY'] || '',
@@ -68,7 +69,7 @@ class CodaVentureService extends CodaService<Venture> {
     }
 
     constructor() {
-        super(VENTURE_TABLE_ID, undefined, coda2Entity, undefined);
+        super(CODA_DOC_ID, VENTURE_TABLE_ID, undefined, coda2Entity, undefined);
     }
 }
 

--- a/services/codaVentureService.ts
+++ b/services/codaVentureService.ts
@@ -1,0 +1,76 @@
+/**
+ *  proctorService.ts
+ *
+ *  @copyright 2024 Digital Aid Seattle
+ *
+ */
+
+import { CodaRow, CodaService } from './codaService';
+
+type Venture = {
+    _id: string
+    _createdAt: Date
+    orderRank: string
+    id: string
+    title: string
+    partner: string
+    painpoint: string
+    programAreas: string[]
+    description: string
+    status: "Submitted by Partner"
+    | "Ready for consideration"
+    | "Active"
+    | "Under evaluation"
+    | "Declined"
+    | "Completed"
+    projectLink: string
+    duration?: { start: string; end: string }
+    problem: string
+    solution: string
+    impact: string
+    display: boolean,
+    imageSrc: string,
+    ventureCode: string
+}
+// @ts-ignore - Environment variables are defined at runtime
+const VENTURE_TABLE_ID = 'grid-UdXLv7wwqh';
+
+function coda2Entity(row: CodaRow): Venture {
+    console.log(row)
+
+    const venture = {
+        title: row.values['c-VmSQh523FY'] || '',
+        status: row.values['c-GuJCl9qMyY'],
+
+        partner: row.values['partner'] || '',
+        painpoint: row.values['painpoint'] || '',
+        programAreas: row.values['programAreas'] ? (row.values['programAreas'] as string).split(',').map(s => s.trim()) : [],
+        description: row.values['description'] || '',
+        projectLink: row.values['projectLink'] || '',
+        problem: row.values['problem'] || '',
+        solution: row.values['solution'] || '',
+        impact: row.values['impact'] || '',
+        display: row.values['display'] || false,
+        imageSrc: row.values['imageSrc'] || '',
+        ventureCode: row.values['ventureCode'] || ''
+    } as Venture;
+    return venture;
+}
+
+class CodaVentureService extends CodaService<Venture> {
+
+    static instance: CodaVentureService;
+    static getInstance(): CodaVentureService {
+        if (!CodaVentureService.instance) {
+            CodaVentureService.instance = new CodaVentureService();
+        }
+        return CodaVentureService.instance;
+    }
+
+    constructor() {
+        super(VENTURE_TABLE_ID, undefined, coda2Entity, undefined);
+    }
+}
+
+export { CodaVentureService };
+

--- a/services/codaVentureService.ts
+++ b/services/codaVentureService.ts
@@ -5,60 +5,42 @@
  *
  */
 
+import { DASProject, TeamMember } from 'types';
 import { CodaRow, CodaService } from './codaService';
-
-type Venture = {
-    _id: string
-    _createdAt: Date
-    orderRank: string
-    id: string
-    title: string
-    partner: string
-    painpoint: string
-    programAreas: string[]
-    description: string
-    status: "Submitted by Partner"
-    | "Ready for consideration"
-    | "Active"
-    | "Under evaluation"
-    | "Declined"
-    | "Completed"
-    projectLink: string
-    duration?: { start: string; end: string }
-    problem: string
-    solution: string
-    impact: string
-    display: boolean,
-    imageSrc: string,
-    ventureCode: string
-}
 
 const CODA_DOC_ID = "24QYb2RP0g";
 const VENTURE_TABLE_ID = 'grid-UdXLv7wwqh';
 
-function coda2Entity(row: CodaRow): Venture {
-    console.log('Venture', row)
-
+function coda2Entity(row: CodaRow): DASProject {
     const venture = {
-        title: row.values['c-VmSQh523FY'] || '',
-        status: row.values['c-GuJCl9qMyY'],
-
-        partner: row.values['partner'] || '',
-        painpoint: row.values['painpoint'] || '',
-        programAreas: row.values['programAreas'] ? (row.values['programAreas'] as string).split(',').map(s => s.trim()) : [],
-        description: row.values['description'] || '',
-        projectLink: row.values['projectLink'] || '',
-        problem: row.values['problem'] || '',
-        solution: row.values['solution'] || '',
-        impact: row.values['impact'] || '',
-        display: row.values['display'] || false,
-        imageSrc: row.values['imageSrc'] || '',
-        ventureCode: row.values['ventureCode'] || ''
-    } as Venture;
+        id: row.id,
+        title: row.values['Ventures'] ? row.values['Ventures'].replaceAll('```', '') : '',
+        status: row.values['Venture Status'] ? row.values['Venture Status'].replaceAll('```', '') : '',
+        imageSrc: row.values['Ventures Icon'] ? row.values['Ventures Icon'][0].url : '',
+        currentTeam: (row.values['Squad Members'] ?? [])
+            .map((member: any) => {
+                return {
+                    name: member['name'] ?? '',
+                    // TODO integrate with voulteer service to get image
+                    // TODO integrate with role service to get role
+                } as TeamMember;
+            }),
+        // partner: row.values['partner'] || '',
+        // painpoint: row.values['painpoint'] || '',
+        // programAreas: row.values['programAreas'] ? (row.values['programAreas'] as string).split(',').map(s => s.trim()) : [],
+        // description: row.values['description'] || '',
+        // projectLink: row.values['projectLink'] || '',
+        // problem: row.values['problem'] || '',
+        // solution: row.values['solution'] || '',
+        // impact: row.values['impact'] || '',
+        // display: row.values['display'] || false,
+        // imageSrc: row.values['imageSrc'] || '',
+        // ventureCode: row.values['ventureCode'] || ''
+    } as DASProject;
     return venture;
 }
 
-class CodaVentureService extends CodaService<Venture> {
+class CodaVentureService extends CodaService<DASProject> {
 
     static instance: CodaVentureService;
     static getInstance(): CodaVentureService {

--- a/services/codaVolunteerService.ts
+++ b/services/codaVolunteerService.ts
@@ -1,0 +1,71 @@
+/**
+ *  proctorService.ts
+ *
+ *  @copyright 2024 Digital Aid Seattle
+ *
+ */
+
+import { Entity } from '@digitalaidseattle/core';
+import { CodaRow, CodaService } from './codaService';
+import { TeamMember } from 'types';
+
+type Volunteer = Entity & {
+    _createdAt: Date,
+    name: string,
+    role: string,
+    status: string[],
+    url: string,
+    cadreContributor: string[],
+}
+
+const CODA_DOC_ID = "24QYb2RP0g";
+const TABLE_ID = 'grid-4vzF6VuaPV';
+
+function coda2Entity(row: CodaRow): Volunteer {
+    const entity = {
+        name: row.values['Name'] ? row.values['Name'].replaceAll('```', '') : '',
+        role: row.values['Position'] ? row.values['Position'].replaceAll('```', '') : '',
+        url: row.values['Pic'] ? row.values['Pic'][0].url : '',
+        cadreContributor: row.values['Cadre or Contributor'] ? row.values['Cadre or Contributor'].map((s: any) => s.replaceAll('```', '')) : [],
+        status: row.values['Status'] ? row.values['Status'].map((s: any) => s.replaceAll('```', '')) : [],
+    } as Volunteer;
+    return entity;
+}
+
+class CodaVolunteerService extends CodaService<Volunteer> {
+
+    static instance: CodaVolunteerService;
+    static getInstance(): CodaVolunteerService {
+        if (!CodaVolunteerService.instance) {
+            CodaVolunteerService.instance = new CodaVolunteerService();
+        }
+        return CodaVolunteerService.instance;
+    }
+
+    constructor() {
+        super(CODA_DOC_ID, TABLE_ID, undefined, coda2Entity, undefined);
+    }
+
+    getPeople(cadreOrContributor: string): Promise<TeamMember[]> {
+        return this.getAll()
+            .then(volunteers => {
+                return volunteers
+                    .filter(v => v.status.includes('Active'))
+                    .filter(v => v.cadreContributor.includes(cadreOrContributor))
+                    .map(v => {
+                        return {
+                            name: v.name,
+                            role: v.role,
+                            url: v.url
+                        } as TeamMember;
+                    })
+            })
+            .catch(error => {
+                console.error('Error fetching volunteers from Coda:', error);
+                return [];
+            });
+    }
+}
+
+export { CodaVolunteerService };
+

--- a/services/codaVolunteerService.ts
+++ b/services/codaVolunteerService.ts
@@ -23,6 +23,7 @@ const TABLE_ID = 'grid-4vzF6VuaPV';
 
 function coda2Entity(row: CodaRow): Volunteer {
     const entity = {
+        id: row.id,
         name: row.values['Name'] ? row.values['Name'].replaceAll('```', '') : '',
         role: row.values['Position'] ? row.values['Position'].replaceAll('```', '') : '',
         url: row.values['Pic'] ? row.values['Pic'][0].url : '',

--- a/types.d.ts
+++ b/types.d.ts
@@ -89,7 +89,7 @@ type DASVolunteerRoleBasicInfo = {
   category: string[]
 }
 
-type DASVolunteerRole = {
+type DASVolunteerRole = Entity & {
   location: string
   duration: string
   headline: string

--- a/yarn.lock
+++ b/yarn.lock
@@ -221,6 +221,11 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
+"@babel/runtime@^7.25.0":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.28.6.tgz#d267a43cb1836dc4d182cce93ae75ba954ef6d2b"
+  integrity sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==
+
 "@babel/runtime@^7.25.6":
   version "7.25.7"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz"
@@ -355,6 +360,16 @@
   integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
+
+"@digitalaidseattle/core@^1.0.16":
+  version "1.0.16"
+  resolved "https://registry.yarnpkg.com/@digitalaidseattle/core/-/core-1.0.16.tgz#80379b020ea8af28290938236adad5a6d2e9a8a7"
+  integrity sha512-+3OIBcTNde8tVK2TMq8jeL8RYqcp93ndfU4grLFOsCTswDQhZe940h0tQHckYQdBAGFUB6h6HgLY/QxA4l/zRw==
+  dependencies:
+    "@babel/runtime" "^7.25.0"
+    react "^18.3.1"
+    react-dom "^18.3.1"
+    typescript "^5.5.4"
 
 "@dnd-kit/accessibility@^3.0.0":
   version "3.0.1"
@@ -7618,6 +7633,11 @@ typescript@^4.9.4:
   version "4.9.4"
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz"
   integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
+
+typescript@^5.5.4:
+  version "5.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
+  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## Summary
- render volunteer process step copy with `react-markdown`
- allow markdown links in the "The process" section to inherit existing `.markdown a` underline styling

## Why
The process section was rendering step copy as plain text inside `Typography`, so markdown links were not getting the existing markdown link styling.

## Validation
- Chrome Dev tools
- `yarn type-check`
- `npx next lint --file pages/volunteers.tsx`