### PR TITLE
DW-201, refactor: Remove partner logo sections from Home and About

### DIFF
--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -39,16 +39,10 @@ import { designColor } from 'theme/theme'
 
 import MastheadWithImage from 'components/MastheadWithImage'
 import AboutUsImage from '../assets/aboutUs.png'
-import AppleLogo from '../assets/aboutUsIcons/apple.svg'
 import GeneticsIcon from '../assets/aboutUsIcons/genetics.svg'
-import GoogleLogo from '../assets/aboutUsIcons/google.svg'
 import HCIIcon from '../assets/aboutUsIcons/hci.svg'
-import MicrosoftLogo from '../assets/aboutUsIcons/microsoft.svg'
-import NOAALogo from '../assets/aboutUsIcons/noaa.svg'
 import NonProfitManagementIcon from '../assets/aboutUsIcons/non_profit_management.svg'
 import PhysicsIcon from '../assets/aboutUsIcons/physics.svg'
-import StarbucksLogo from '../assets/aboutUsIcons/starbucks.svg'
-import VerizonLogo from '../assets/aboutUsIcons/verizon.svg'
 import { useEffect, useState } from 'react'
 import { pageCopyService } from 'services/PageCopyService'
 import { useRouter } from 'next/router'
@@ -74,7 +68,6 @@ const LABELS = {
 
   OUR_EXPERIENCE_LBL: 'Our experience',
   OUR_EXPERIENCE_TXT: 'Digital Aid Seattle’s team brings together highly skilled and committed volunteers with deep experience across tech and management, dedicated to serving the greater Seattle area.',
-  COMPANIES_TXT: 'We’ve worked in tech and management for companies like:',
   EXPERIENCE_TXT: 'We collectively hold experience in:',
   DEGREES_TXT: 'We have graduate and post-graduate degrees in:'
 }
@@ -255,24 +248,6 @@ const OurExperienceSection = () => {
         display="block"
         component="h3"
       >
-        {LABELS.COMPANIES_TXT}
-      </Typography>
-      <Grid container spacing={2} component="ul">
-        {companiesList.map((item) => (
-          <Grid item xs={6} md={4} key={item.label}>
-            <ListItemWithIcon
-              listIcon={item.icon}
-              listText={!isMediumOrSmallerScreen && item.label}
-            />
-          </Grid>
-        ))}
-      </Grid>
-      <Typography
-        variant="titleMedium"
-        align="center"
-        display="block"
-        component="h3"
-      >
         {LABELS.EXPERIENCE_TXT}
       </Typography>
       <Grid container spacing={2} component="ul">
@@ -308,33 +283,6 @@ const OurExperienceSection = () => {
     </AboutUsSection>
   )
 }
-
-const companiesList = [
-  {
-    label: 'Apple',
-    icon: <img src={AppleLogo.src} alt="Apple logo" width="40px" />,
-  },
-  {
-    label: 'Google',
-    icon: <img src={GoogleLogo.src} alt="Google logo" width="40px" />,
-  },
-  {
-    label: 'Verizon',
-    icon: <img src={VerizonLogo.src} alt="Verizon logo" width="40px" />,
-  },
-  {
-    label: 'Microsoft',
-    icon: <img src={MicrosoftLogo.src} alt="Microsoft logo" width="40px" />,
-  },
-  {
-    label: 'Starbucks',
-    icon: <img src={StarbucksLogo.src} alt="Starbucks logo" width="40px" />,
-  },
-  {
-    label: 'NOAA',
-    icon: <img src={NOAALogo.src} alt="NOAA logo" width="40px" />,
-  },
-]
 
 const experienceContent = [
   {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,7 @@
 import Groups2OutlinedIcon from '@mui/icons-material/Groups2Outlined'
 import HandshakeOutlinedIcon from '@mui/icons-material/HandshakeOutlined'
 import VolunteerActivismIcon from '@mui/icons-material/VolunteerActivism';
-import { Avatar, Box, Button, Stack, Typography, useTheme } from '@mui/material'
+import { Box, Button, Stack, Typography, useTheme } from '@mui/material'
 import useMediaQuery from '@mui/material/useMediaQuery'
 import CardOne from 'components/cards/CardOne'
 import SectionContainer from 'components/layout/SectionContainer'
@@ -14,11 +14,6 @@ import HeroImage from '../public/images/SeattleSkyline.jpg'
 import { useEffect, useState } from 'react'
 import { pageCopyService } from 'services/PageCopyService'
 
-import GoogleLogo from '../assets/aboutUsIcons/google.svg';
-import MicrosoftLogo from '../assets/aboutUsIcons/microsoft.svg';
-import SlalomLogo from '../assets/aboutUsIcons/slalom.png';
-import CityOfSeattleLogo from '../assets/aboutUsIcons/cityofseattle.png';
-import AWSLogo from '../assets/aboutUsIcons/aws.png';
 import { useRouter } from 'next/router';
 
 // TODO consider moving into Sanity
@@ -50,8 +45,7 @@ const LABELS = {
   VALUE_TITLE: '$936,000 in Value',
   VALUE_TEXT: 'Pro-bono services that allow you to reallocate scarce funds back into programs.',
   IMPACT_LABEL: 'Our impact',
-  LEARN_MORE_BTN: 'Learn more',
-  ALLIES_LABEL: 'Our allies'
+  LEARN_MORE_BTN: 'Learn more'
 }
 
 const HeroSection: React.FC = () => {
@@ -511,56 +505,6 @@ const ImpactSection: React.FC = () => {
   );
 }
 
-const allies = [
-  {
-    label: 'google',
-    icon: GoogleLogo.src,
-  },
-  {
-    label: 'Microsoft',
-    icon: MicrosoftLogo.src,
-  },
-  {
-    label: 'Slalom',
-    icon: SlalomLogo.src,
-  },
-  {
-    label: 'City Of Seattle',
-    icon: CityOfSeattleLogo.src,
-  },
-  {
-    label: 'Amazon Web Services',
-    icon: AWSLogo.src,
-  },
-]
-
-const AlliesSection: React.FC = () => {
-  return (
-    <Stack
-      sx={{
-        gap: { xs: 3, lg: 10 },
-        justifyContent: 'space-around',
-        alignItems: 'center',
-        marginBottom: { sm: 4, lg: 10 },
-      }}
-      maxWidth={'880px'}
-    >
-      <Typography variant="headlineLarge" component="h2">
-        {LABELS.ALLIES_LABEL}
-      </Typography>
-      <Stack direction={'row'} spacing={4} >
-        {allies.map((item, index) => (
-          <Avatar
-            key={`logo-${index}`}
-            alt={item.label}
-            src={item.icon}
-            sx={{ width: 124, height: 124 }} />
-        ))}
-      </Stack>
-    </Stack>
-  );
-}
-
 const Home = () => {
   const theme = useTheme()
   const palette = theme.palette
@@ -588,9 +532,6 @@ const Home = () => {
       </SectionContainer>
       <SectionContainer backgroundColor={palette.background.default}>
         <ImpactSection />
-      </SectionContainer>
-      <SectionContainer backgroundColor={palette.background.paper}>
-        <AlliesSection />
       </SectionContainer>
     </>
   )


### PR DESCRIPTION
## Description

Removes the two allies logo rows from the site.

- Home page: the "Our allies" section at the bottom, a heading plus five logos (Google, Microsoft, Slalom, City of Seattle, AWS).
- About page: inside "Our experience", the line "We've worked in tech and management for companies like:" and its logo grid (Apple, Google, Verizon, Microsoft, Starbucks, NOAA).

Deletions only, no new code. Both files also drop the copy labels and imports that became unused as a result.

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related Tickets & Documents

- Related Issue #
- Closes # DW-201

## QA Instructions, Screenshots, Recordings

1. Open Home and scroll to the bottom. The "Our allies" heading and logo row are gone, and the page ends after "Our impact" with no empty band or doubled background color.
2. Open About and scroll to "Our experience". The "We've worked in tech and management for companies like:" line and its logo grid are gone.
