### PR TITLE
DW-202, bugfix: show project logos on mobile

### DIFF
--- a/components/cards/CardProject.tsx
+++ b/components/cards/CardProject.tsx
@@ -60,10 +60,9 @@ const CardProject = ({ project }: CardProjectProps) => {
               alt={project.title + " logo"}
               sx={{
                 objectFit: 'contain',
-                width: { md: '7rem', lg: '100%' },
+                width: { xs: '7rem', lg: '100%' },
                 aspectRatio: '1 / 1',
                 borderRadius: '8px',
-                display: { xs: 'none', md: 'block' },
                 backgroundColor: 'white',
               }}
             />


### PR DESCRIPTION
## Description

Project logos did not appear on the projects page on phones.

The project card had a rule that hid the logo on screens under 600px wide. The logo was present in the data and the image file loaded fine. It was simply set to `display: none`. This PR removes that rule, which fixes the bug.

Files changed: `components/cards/CardProject.tsx`

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related Tickets & Documents

- Closes # DW-202

## QA Instructions, Screenshots, Recordings

1. Open `/projects` in responsive mode at 390px wide.
2. Each project card shows a square logo to the left of the title and status badge.
3. Slowly widen the viewport past 600px. The logo stays the same size, with no pop in or out at the boundary.
4. Widen past 960px. The logo moves above the title at full card width, matching current production.

