### PR TITLE
DW-203, bugfix: fix mobile nav menu

### DIFF
--- a/components/CommonHeader.tsx
+++ b/components/CommonHeader.tsx
@@ -29,16 +29,11 @@ const DEFAULT_MENU_ITEMS = [
 ]
 
 const lookup = (supportUs: any): any[] => {
-  if (supportUs.status === 'fetched') {
-    const items = DEFAULT_MENU_ITEMS.slice()
-    if (supportUs.data) {
-      items.push({ label: 'Donate', path: '/donate', style: 'secondary', pages: ['donate'] })
-    }
-    return items;
+  const items = DEFAULT_MENU_ITEMS.slice()
+  if (supportUs.status === 'fetched' && supportUs.data) {
+    items.push({ label: 'Donate', path: '/donate', style: 'secondary', pages: ['donate'] })
   }
-  else {
-    return [];
-  }
+  return items;
 }
 
 const CommonHeader = () => {
@@ -102,6 +97,10 @@ const CommonHeader = () => {
           className="link"
           style={{
             color: theme.palette.primary.contrastText,
+            textUnderlineOffset: '0.5rem',
+            textDecoration: isCurrent(menuItem)
+              ? 'underline'
+              : 'none'
           }}
           href={menuItem.path}
         >
@@ -178,7 +177,7 @@ const CommonHeader = () => {
         {/* mobile slide-out menu */}
         {smallScreen &&
           <Box sx={{ position: 'relative', zIndex: -1 }}>
-            <MobileMenu yTranslate={showMobileMenu ? '0' : '-500px'}>
+            <MobileMenu yTranslate={showMobileMenu ? '0' : '-100%'} open={showMobileMenu}>
               {menuItems.map((menuItem, idx) =>
                 mobileMenuItem(menuItem, idx)
               )}

--- a/components/MobileMenu.tsx
+++ b/components/MobileMenu.tsx
@@ -12,14 +12,18 @@ import { ReactNode } from 'react'
 type MobileMenuProps = {
   children: ReactNode;
   yTranslate: string;
+  open: boolean;
 }
 
-const MobileMenu = ({ children, yTranslate }: MobileMenuProps) => {
+const MobileMenu = ({ children, yTranslate, open }: MobileMenuProps) => {
   const theme = useTheme()
 
   return (
   <List 
     aria-label="navigation"
+    // Closed, the menu is only moved off-screen, so it stays focusable without this.
+    aria-hidden={!open}
+    inert={!open}
     sx={{
       display: 'flex',
       flexDirection: 'column',
@@ -31,7 +35,7 @@ const MobileMenu = ({ children, yTranslate }: MobileMenuProps) => {
       backgroundColor: theme.palette.primary.main,
       borderBottom: `2px solid ${theme.palette.text.primary}`,
       transform: `translateY(${yTranslate})`,
-      transition: 'all 0.66s ease',
+      transition: 'transform 0.25s ease',
   }}>
       {children}
     </List>


### PR DESCRIPTION
## Description

Fixed mobile menu opening speed, and underlined the currently open page.

- Slide transition is `transform 0.25s` instead of `all 0.66s`. The old one animated
  every property and was slow enough to feel broken.
- The header rendered nothing at all until the `support-us` feature flag resolved. The
  default items now render right away and Donate is appended when the flag lands.
- Mobile menu items underline the current page, matching what desktop items already did.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related Tickets & Documents

- Closes # DW-203

## QA Instructions, Screenshots, Recordings

1. At phone width, load any page. Once you open the menu, all items appear right away, while waiting for the Donate button to load.
2. Tap the hamburger, then tap the X. The menu slides down and back up in about a
   quarter second, with no sliver of it left showing at the top.
3. Go to `/projects` and open the menu. "Projects" is underlined.
4. At desktop width, confirm the header renders the same items and Donate still appears.
