### PR TITLE
DW-205: fix card content alignment and home page overflow

### DIFF
--- a/components/cards/CardOne.tsx
+++ b/components/cards/CardOne.tsx
@@ -91,7 +91,7 @@ const CardOne = ({
       }}
     >
       {cardHref && <CardActionArea onClick={() => router.push(cardHref)}>{content}</CardActionArea>}
-      {!cardHref && <CardContent>{content}</CardContent>}
+      {!cardHref && <CardContent sx={{ flexGrow: 1 }}>{content}</CardContent>}
     </Card>
   )
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -363,10 +363,10 @@ const WhyDASSection: React.FC = () => {
     }}
     maxWidth={'880px'}
   >
-    <Typography variant="headlineLarge" component="h2">
+    <Typography variant="headlineLarge" component="h2" textAlign={'center'}>
       {LABELS.WHY_DAS_LABEL}
     </Typography>
-    <Typography variant='labelLarge'>
+    <Typography variant='labelLarge' textAlign={'center'}>
       {LABELS.WHY_DAS_SUBTITLE_LABEL}
     </Typography>
     <Typography textAlign={'center'} >
@@ -443,7 +443,7 @@ const HowItWorksSection: React.FC = () => {
         cardStyles={cardStyles}
       />
     </CardGridContainer>
-    <Typography variant='labelLarge'>
+    <Typography variant='labelLarge' textAlign={'center'}>
       {LABELS.HOW_SUBTITLE_LABEL}
     </Typography>
     <Button
@@ -548,13 +548,13 @@ const AlliesSection: React.FC = () => {
       <Typography variant="headlineLarge" component="h2">
         {LABELS.ALLIES_LABEL}
       </Typography>
-      <Stack direction={'row'} spacing={4} >
+      <Stack direction={'row'} spacing={4} useFlexGap flexWrap="wrap" justifyContent="center" >
         {allies.map((item, index) => (
           <Avatar
             key={`logo-${index}`}
             alt={item.label}
             src={item.icon}
-            sx={{ width: 124, height: 124 }} />
+            sx={{ width: 80, height: 80 }} />
         ))}
       </Stack>
     </Stack>


### PR DESCRIPTION
## Description

Cards centred their content on the text instead of on the card, so icons and buttons sat left of centre. Also fixes two home page issues found while testing: headings went ragged when they wrapped, and the ally logos made the page scroll sideways.


## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related Tickets & Documents

- Related Issue # DW-205
- Closes # DW-205

## QA Instructions, Screenshots, Recordings

1. Open the home page at 800px wide. Every card centres its icon, text and button.
2. Narrow to 320px. Headings and card contents stay centred.
3. Still at 320px, scroll to the bottom. Nothing scrolls sideways, and the ally logos wrap into centred rows.
