### PR TITLE
A/B toggle for LinkedIn icon placement on the team page

### DIFF
--- a/components/cards/CardWithPhoto.tsx
+++ b/components/cards/CardWithPhoto.tsx
@@ -16,6 +16,8 @@ type CardWithPhotoProps = {
   subtitle?: string
   // undefined -> no LinkedIn icon; '' -> static icon (no link); url -> clickable icon
   linkedInUrl?: string
+  // 'below' (default) keeps the icon at the card bottom; 'inline' places it beside the title
+  linkedInPlacement?: 'below' | 'inline'
   titleSx?: Record<string, any>
   subtitleSx?: Record<string, any>
   descriptionSx?: Record<string, any>
@@ -32,6 +34,7 @@ const CardWithPhoto = ({
   alt = '',
   subtitle,
   linkedInUrl,
+  linkedInPlacement = 'below',
   titleSx,
   subtitleSx,
   descriptionSx,
@@ -39,6 +42,36 @@ const CardWithPhoto = ({
   onClick,
 }: CardWithPhotoProps) => {
   const src = image || fallbackImage
+
+  const linkedInIcon = linkedInUrl !== undefined &&
+    (linkedInUrl ? (
+      <Link
+        href={linkedInUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        title="LinkedIn"
+        aria-label={`${title}'s LinkedIn profile, which opens in a new window.`}
+        onClick={(e) => e.stopPropagation()}
+        sx={
+          linkedInPlacement === 'below'
+            ? { alignSelf: 'flex-start', marginTop: 'auto', lineHeight: 0 }
+            : { verticalAlign: 'middle' }
+        }
+      >
+        <LinkedIn sx={{ color: designColor.linkedInBlue }} fontSize="medium" />
+      </Link>
+    ) : (
+      <LinkedIn
+        titleAccess={`${title} on LinkedIn`}
+        sx={{
+          color: designColor.linkedInBlue,
+          ...(linkedInPlacement === 'below'
+            ? { alignSelf: 'flex-start', marginTop: 'auto' }
+            : { verticalAlign: 'middle' }),
+        }}
+        fontSize="medium"
+      />
+    ))
 
   return (
     <Card
@@ -80,6 +113,12 @@ const CardWithPhoto = ({
       >
         <Typography variant="titleMedium" sx={titleSx}>
           {title}
+          {linkedInPlacement === 'inline' && linkedInIcon && (
+            <>
+              {' '}
+              {linkedInIcon}
+            </>
+          )}
         </Typography>
         {subtitle && (
           <Typography
@@ -96,30 +135,7 @@ const CardWithPhoto = ({
             {description}
           </Typography>
         )}
-        {linkedInUrl !== undefined &&
-          (linkedInUrl ? (
-            <Link
-              href={linkedInUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              title="LinkedIn"
-              aria-label={`${title}'s LinkedIn profile, which opens in a new window.`}
-              onClick={(e) => e.stopPropagation()}
-              sx={{ alignSelf: 'flex-start', marginTop: 'auto', lineHeight: 0 }}
-            >
-              <LinkedIn sx={{ color: designColor.linkedInBlue }} fontSize="medium" />
-            </Link>
-          ) : (
-            <LinkedIn
-              titleAccess={`${title} on LinkedIn`}
-              sx={{
-                color: designColor.linkedInBlue,
-                alignSelf: 'flex-start',
-                marginTop: 'auto',
-              }}
-              fontSize="medium"
-            />
-          ))}
+        {linkedInPlacement === 'below' && linkedInIcon}
       </CardContent>
     </Card>
   )

--- a/components/cards/CardWithPhoto.tsx
+++ b/components/cards/CardWithPhoto.tsx
@@ -55,7 +55,7 @@ const CardWithPhoto = ({
         sx={
           linkedInPlacement === 'below'
             ? { alignSelf: 'flex-start', marginTop: 'auto', lineHeight: 0 }
-            : { verticalAlign: 'middle' }
+            : { verticalAlign: '0.15em' }
         }
       >
         <LinkedIn sx={{ color: designColor.linkedInBlue }} fontSize="medium" />
@@ -67,7 +67,7 @@ const CardWithPhoto = ({
           color: designColor.linkedInBlue,
           ...(linkedInPlacement === 'below'
             ? { alignSelf: 'flex-start', marginTop: 'auto' }
-            : { verticalAlign: 'middle' }),
+            : { verticalAlign: '0.15em' }),
         }}
         fontSize="medium"
       />

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/pages/team.tsx
+++ b/pages/team.tsx
@@ -3,7 +3,7 @@
  */
 import { useContext, useEffect, useState } from 'react'
 
-import { Box, Stack, useTheme } from '@mui/material'
+import { Box, Stack, ToggleButton, ToggleButtonGroup, Typography, useTheme } from '@mui/material'
 
 import CardWithPhoto from 'components/cards/CardWithPhoto'
 import SectionContainer from 'components/layout/SectionContainer'
@@ -17,6 +17,7 @@ import {
 import { useVolunteers } from 'components/useVolunteers'
 import { boardMembers } from 'data/boardMembers'
 import { pageCopyService } from 'services/PageCopyService'
+import { designColor } from 'theme/theme'
 import { DASProject, Volunteer } from 'types'
 import NoPhotoPerson from '../assets/no-photo-person.svg'
 import ProjectImage from '../assets/project-image.png'
@@ -46,7 +47,11 @@ function sortByFirstName<T extends { name: string }>(arr: T[]): T[] {
   )
 }
 
-const MemberGridSection = (props: { title: string; members: MemberItem[] }) => {
+const MemberGridSection = (props: {
+  title: string
+  members: MemberItem[]
+  linkedInPlacement: 'below' | 'inline'
+}) => {
   return (
     props.members.length > 0 && (
       <ProjectSection>
@@ -79,12 +84,73 @@ const MemberGridSection = (props: { title: string; members: MemberItem[] }) => {
                 fallbackImage={NoPhotoPerson.src}
                 alt={`headshot of ${member.name}`}
                 linkedInUrl={member.linkedInUrl}
+                linkedInPlacement={props.linkedInPlacement}
               />
             </Box>
           ))}
         </Box>
       </ProjectSection>
     )
+  )
+}
+
+const VariantToggle = (props: {
+  variant: 'A' | 'B'
+  onChange: (variant: 'A' | 'B') => void
+}) => {
+  return (
+    <Box
+      sx={{
+        position: 'fixed',
+        bottom: '1.5rem',
+        right: '1.5rem',
+        zIndex: 1200,
+        backgroundColor: 'background.paper',
+        boxShadow:
+          '0px 4px 8px 2px rgba(52, 61, 62, 0.04), 0px 2px 4px rgba(52, 61, 62, 0.04)',
+        padding: '0.5rem',
+        borderRadius: '4px',
+        border: '2px solid #EAF1F1',
+      }}
+    >
+      <Typography
+        variant="labelSmall"
+        sx={{ display: 'block', textAlign: 'center', marginBottom: '0.25rem' }}
+      >
+        LinkedIn icon
+      </Typography>
+      <ToggleButtonGroup
+        value={props.variant}
+        exclusive
+        onChange={(_, value) => value !== null && props.onChange(value)}
+        aria-label="LinkedIn icon placement variant"
+        sx={{
+          '& .MuiToggleButton-root': {
+            color: 'text.primary',
+            '&.Mui-selected': {
+              backgroundColor: designColor.green.main,
+              color: designColor.white,
+              '&:hover': {
+                backgroundColor: designColor.green.main,
+              },
+            },
+          },
+        }}
+      >
+        <ToggleButton value="A" aria-label="Variant A: LinkedIn icon below name">
+          A
+          <Typography variant="labelSmall" component="span" color="inherit" sx={{ marginLeft: '0.25rem' }}>
+            below
+          </Typography>
+        </ToggleButton>
+        <ToggleButton value="B" aria-label="Variant B: LinkedIn icon inline with name">
+          B
+          <Typography variant="labelSmall" component="span" color="inherit" sx={{ marginLeft: '0.25rem' }}>
+            beside
+          </Typography>
+        </ToggleButton>
+      </ToggleButtonGroup>
+    </Box>
   )
 }
 
@@ -98,6 +164,7 @@ const TeamPage = () => {
   const [board, setBoard] = useState<Volunteer[]>([])
   const [cadre, setCadre] = useState<Volunteer[]>([])
   const [contributors, setContributors] = useState<Volunteer[]>([])
+  const [variant, setVariant] = useState<'A' | 'B'>('A')
 
   useEffect(() => {
     if (!initialized) {
@@ -154,25 +221,28 @@ const TeamPage = () => {
     name: v.name,
     role: v.role,
     image: v.url,
-  })
-
-  const toBoardItem = (v: Volunteer): MemberItem => ({
-    ...toMemberItem(v),
-    linkedInUrl: v.linkedIn,
+    linkedInUrl: v.linkedIn || undefined,
   })
 
   function getBody() {
+    const linkedInPlacement = variant === 'A' ? 'below' : 'inline'
     return (
       <SectionContainer backgroundColor={theme.palette.background.default}>
         <Stack gap={{ xs: '64px', lg: '80px' }} maxWidth="880px" margin="0 auto">
-          <MemberGridSection title={LABELS.BOARD_LBL} members={board.map(toBoardItem)} />
+          <MemberGridSection
+            title={LABELS.BOARD_LBL}
+            members={board.map(toMemberItem)}
+            linkedInPlacement={linkedInPlacement}
+          />
           <MemberGridSection
             title={LABELS.CADRE_LBL}
             members={cadre.map(toMemberItem)}
+            linkedInPlacement={linkedInPlacement}
           />
           <MemberGridSection
             title={LABELS.CONTRIBUTORS_LBL}
             members={contributors.map(toMemberItem)}
+            linkedInPlacement={linkedInPlacement}
           />
         </Stack>
       </SectionContainer>
@@ -193,6 +263,7 @@ const TeamPage = () => {
         />
         {project ? getBody() : <></>}
         <ProjectFooterSection />
+        <VariantToggle variant={variant} onChange={setVariant} />
       </Box>
     </BlockComponent>
   )


### PR DESCRIPTION
Adds a floating A/B toggle to `/team` so we can compare two LinkedIn icon placements on a preview build and pick one. Cadre and Contributors now get a LinkedIn icon, which previously only Board members had.

**Do not merge as is.** The A/B toggle is visible to every visitor. Once we pick a variant, the toggle comes out and the winner gets hardcoded.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related Tickets & Documents

- Related Issue
None